### PR TITLE
Set log path via CLI and update default log path in Dockerfile

### DIFF
--- a/.github/workflows/enforce-versioning.yaml
+++ b/.github/workflows/enforce-versioning.yaml
@@ -73,9 +73,9 @@ jobs:
           head_version=${{ needs.get-version.outputs.semver-head }}
           main_version=${{ needs.get-version.outputs.semver-main }}
 
-          ./scripts/check_source_changed.sh -b origin/main
+          ./scripts/check_source_changed.sh -b origin/main || exit_code=$?
          
-          if [[ "$?" -eq 0 ]]; then
+          if [[ -z $exit_code ]]; then
             if [[ $head_version == $main_version ]]; then
               echo "Source has not changed and neither has the version, no action needed 😎👍."
               exit 0
@@ -83,7 +83,7 @@ jobs:
               echo "🚨 🖐️👮 Source has not changed, but the version has changed. Change the version back to $main_version! 🚨" >&2
               exit 1
             fi
-          elif [[ "$?" -eq 1 ]]; then
+          elif [[ $exit_code -eq 1 ]]; then
             if [[ $head_version == $main_version ]]; then
               echo "🚨 🖐️👮 Source has changed, but the version has not been updated. Increase the version! 🚨" >&2
               exit 1
@@ -92,5 +92,5 @@ jobs:
               exit 0
             fi
           else
-            exit 1
+            exit $exit_code
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "budgeteur_rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "askama",
  "askama_axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "budgeteur_rs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 default-run = "server"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,7 @@ COPY --from=build /build/target/release/reset_password /usr/local/bin/reset_pass
 
 EXPOSE 3000
 
-CMD [ "server", "--db-path", "/app/data/budgeteur.db", "-a", "0.0.0.0", "-p", "8080" ]
+CMD [ "server", "--db-path", "/app/data/budgeteur.db", \
+  "--log-path", "/app/data/debug.log", \
+  "-a", "0.0.0.0", \
+  "-p", "8080" ]

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,7 +6,11 @@ services:
     # breakages.
     image: ghcr.io/anthonydickson/budgeteur:latest
     # This is the same as the default command defined in the image.
-    command: server --address 0.0.0.0 --port 8080 --db-path /app/data/budgeteur.db
+    command: |
+      server --address 0.0.0.0 \
+        --port 8080 \
+        --db-path /app/data/budgeteur.db \
+        --log-path /app/data/debug.log
     ports:
       # Change the port on the left if you want to change the port your PC
       # connects to.

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
   web:
     # Replace 'latest' with the latest version tag, e.g. 0.1.0 to avoid suprise
     # breakages.
-    image: anthonydickson/budgeteur:latest
+    image: ghcr.io/anthonydickson/budgeteur:latest
     # This is the same as the default command defined in the image.
     command: server --address 0.0.0.0 --port 8080 --db-path /app/data/budgeteur.db
     ports:

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -44,13 +44,17 @@ struct Args {
     /// The port to serve the API from.
     #[arg(short, long, default_value_t = 3000)]
     port: u16,
+
+    /// File path to the application logs.
+    #[arg(short, long, default_value = "debug.log")]
+    log_path: String,
 }
 
 #[tokio::main]
 async fn main() {
-    setup_logging();
-
     let args = Args::parse();
+
+    setup_logging(&args.log_path);
 
     let Ok(address) = args.address.parse::<Ipv4Addr>() else {
         eprintln!(
@@ -105,13 +109,13 @@ async fn main() {
     }
 }
 
-fn setup_logging() {
+fn setup_logging(log_path: &str) {
     let stdout_log = tracing_subscriber::fmt::layer().pretty();
 
     let log_file = OpenOptions::new()
         .create(true)
         .append(true)
-        .open("debug.log")
+        .open(log_path)
         .expect("Could not create log file");
 
     let debug_log = tracing_subscriber::fmt::layer()


### PR DESCRIPTION
- Add option to configure log path via CLI argument
- Fix image name in compose.yaml not including 'ghcr.io'
- Set default log path in Docker image to mounted volume.