### PR TITLE
Fix CD pipeline not setting version correctly for Docker job

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,8 +15,8 @@ env:
 
 
 jobs:
-  get-app-version:
-    name: Get App Version
+  get-version:
+    name: Get Version
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
@@ -46,7 +46,7 @@ jobs:
   enforce-unique-tag:
     name: Enforce Unique Image Tag
     runs-on: ubuntu-latest
-    needs: get-app-version
+    needs: get-version
 
     permissions:
       contents: read
@@ -88,7 +88,7 @@ jobs:
           fi
 
           exit_code=""
-          RESULT=$(docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.get-app-version.outputs.semver }} 2>&1 || exit_code=$?)
+          RESULT=$(docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.get-version.outputs.semver }} 2>&1 || exit_code=$?)
 
           if [[ -n $exit_code && $RESULT != "manifest unknown" ]]; then
             echo "❗Error $exit_code: $RESULT"
@@ -106,7 +106,9 @@ jobs:
   build-and-push-image:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    needs: enforce-unique-tag
+    needs:
+      - get-version
+      - enforce-unique-tag
     if: ${{ success() && needs.enforce-unique-tag.outputs.skip == 'false' }}
 
     permissions:
@@ -138,7 +140,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.get-app-version.outputs.semver }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.get-version.outputs.semver }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate Artifact Attestation

--- a/.github/workflows/enforce-versioning.yaml
+++ b/.github/workflows/enforce-versioning.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - develop
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/manual_docker_build.yaml
+++ b/.github/workflows/manual_docker_build.yaml
@@ -1,0 +1,127 @@
+# This workflow is needed for when the automated CD workflow failed to deploy,
+# and the bugfix will not trigger it.
+name: Build & Push Docker Image (Manually Triggered)
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: anthonydickson/budgeteur
+
+jobs:
+  get-version:
+    name: Get Version
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
+    outputs:
+      semver: ${{ steps.version.outputs.semver }}
+    
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: Cargo.toml
+          sparse-checkout-cone-mode: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+
+      - name: Read Version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(python -c 'import tomllib; f = open("Cargo.toml", "rb"); print(tomllib.load(f)["package"]["version"])')
+          echo "semver=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "${VERSION}"
+
+                    
+  enforce-unique-tag:
+    name: Enforce Unique Image Tag
+    runs-on: ubuntu-latest
+    needs: get-version
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if tag exists
+        id: tag-check
+        run: |
+          RESULT=$(docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.get-version.outputs.semver }} 2>&1 || exit_code=$?)
+
+          if [[ -n $exit_code && $RESULT != "manifest unknown" ]]; then
+            echo "❗Error $exit_code: $RESULT"
+            exit 1
+          fi
+
+          if [ "$RESULT" != "manifest unknown" ]; then
+            echo "🚨 Tag already exists, update the version in Cargo.toml! 🚨"
+            exit 1
+          fi
+
+          echo "✅ Tag is unique, proceeding with build"
+
+  build-and-push-image:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    needs:
+      - get-version
+      - enforce-unique-tag
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and Push Docker Image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.get-version.outputs.semver }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate Artifact Attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+# TODO: Once stable (1.0.0), tag image twice, once with full semver and
+# again with the major version. This will allow me to pin to a major version
+# on my NAS and have it download updates with a single click.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Budgeteur-rs
+[![Build & Test](https://github.com/AnthonyDickson/budgeteur-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/AnthonyDickson/budgeteur-rs/actions/workflows/ci.yml)
+[![Build & Push Docker Image](https://github.com/AnthonyDickson/budgeteur-rs/actions/workflows/cd.yaml/badge.svg)](https://github.com/AnthonyDickson/budgeteur-rs/actions/workflows/cd.yaml)
 
 Budgeteur is a budgeting and personal finance web-app.
 


### PR DESCRIPTION
The Docker job was not setting the get-version job as needed, which meant the version was an empty string.
A separate pipeline was added to manually trigger the Docker build pipeline in cases where the automated one failed due to a bug.