### PR TITLE
Fix the example Docker compose file

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,9 +7,9 @@ services:
     image: ghcr.io/anthonydickson/budgeteur:latest
     # This is the same as the default command defined in the image.
     command: |
-      server --address 0.0.0.0 \
-        --port 8080 \
-        --db-path /app/data/budgeteur.db \
+      server --address 0.0.0.0 
+        --port 8080 
+        --db-path /app/data/budgeteur.db
         --log-path /app/data/debug.log
     ports:
       # Change the port on the left if you want to change the port your PC


### PR DESCRIPTION
The backslashes caused the command arguments to be misinterpreted.