### PR TITLE
Fix bug with upsert in SQLiteBalanceStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "budgeteur_rs"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "askama",
  "askama_axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "budgeteur_rs"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 default-run = "server"
 

--- a/src/routes/views/import.rs
+++ b/src/routes/views/import.rs
@@ -83,12 +83,7 @@ where
             }
         };
 
-        tracing::debug!(
-            "Received file '{}' that is {} bytes: {}",
-            file_name,
-            data.len(),
-            data
-        );
+        tracing::debug!("Received file '{}' that is {} bytes", file_name, data.len());
 
         match parse_csv(&data) {
             Ok(parse_result) => {

--- a/src/routes/views/import.rs
+++ b/src/routes/views/import.rs
@@ -53,6 +53,11 @@ where
 {
     let mut transactions = Vec::new();
     let mut balances = Vec::new();
+    let unexpected_error_response = ImportTransactionFormTemplate {
+        import_route: endpoints::IMPORT,
+        error_message: "An unexpected error occurred, please try again later.",
+    }
+    .into_response();
 
     while let Some(field) = multipart.next_field().await.unwrap() {
         if field.content_type() != Some("text/csv") {
@@ -63,8 +68,20 @@ where
             .into_response();
         }
 
-        let file_name = field.file_name().unwrap().to_string();
-        let data = field.text().await.unwrap();
+        let file_name = match field.file_name() {
+            Some(file_name) => file_name.to_owned(),
+            None => {
+                tracing::error!("Could not get file name from multipart form field: {field:#?}");
+                return unexpected_error_response;
+            }
+        };
+        let data = match field.text().await {
+            Ok(data) => data,
+            Err(error) => {
+                tracing::error!("Could not read data from multipart form: {error}");
+                return unexpected_error_response;
+            }
+        };
 
         tracing::debug!(
             "Received file '{}' that is {} bytes: {}",
@@ -94,12 +111,7 @@ where
 
     if let Err(error) = state.transaction_store.import(transactions) {
         tracing::error!("Failed to import transactions: {}", error);
-
-        return ImportTransactionFormTemplate {
-            import_route: endpoints::IMPORT,
-            error_message: "An unexpected error occurred, please try again later.",
-        }
-        .into_response();
+        return unexpected_error_response;
     }
 
     for balance in balances {
@@ -108,13 +120,8 @@ where
                 .balance_store
                 .upsert(&balance.account, balance.balance, &balance.date)
         {
-            tracing::error!("Failed to import account balances: {}", error);
-
-            return ImportTransactionFormTemplate {
-                import_route: endpoints::IMPORT,
-                error_message: "An unexpected error occurred, please try again later.",
-            }
-            .into_response();
+            tracing::error!("Failed to import account balances: {error:#?}");
+            return unexpected_error_response;
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug with upsert when the same CSV, and therefore the same balances, are imported twice.
    
When using the last inserted row id to fetch the balance row, if there was a conflict which resulted in no rows being inserted/updated, the row id would either be zero if the database connection was reset, or the
last successfully inserted row otherwise. 
In the first case, this resulted in an error 'NotFound: the requested resource could not be found', and in the second case it would result in an unrelated balance being returned.

This was fixed by fetching the balance row by account, rather than the last inserted row id.

Other changes:
- Replace unwraps in import view route handler with proper error handling
- Stop logging CSV files in import function.