### PR TITLE
Parse Kiwibank simple CSV exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "budgeteur_rs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "askama",
  "askama_axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "budgeteur_rs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 default-run = "server"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ RUN apk add --no-cache musl-dev
 
 WORKDIR /build
 
-COPY Cargo.toml ./Cargo.toml 
-COPY Cargo.lock ./Cargo.lock
-COPY templates ./templates 
-COPY src/ ./src
+COPY Cargo.toml /build/Cargo.toml
+COPY Cargo.lock /build/Cargo.lock
+COPY templates/ /build/templates/
+COPY src/ /build/src/
 
 RUN cargo build --verbose --release --bin server --bin reset_password
 
@@ -34,7 +34,6 @@ FROM alpine:3.21 AS deploy
 
 WORKDIR /app
 
-COPY templates ./templates 
 COPY static/ ./static
 COPY --from=tailwind /build/static/main.css /app/static/main.css
 COPY --from=build /build/target/release/server /usr/local/bin/server

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The application consists of a single server that renders and serves HTML directl
 <!--toc:start-->
 - [Budgeteur-rs](#budgeteur-rs)
   - [Installation and Usage](#installation-and-usage)
+    - [First-Time Usage](#first-time-usage)
+    - [Resetting Your Password](#resetting-your-password)
   - [Set Up Development Environment](#set-up-development-environment)
     - [Nix Flake](#nix-flake)
     - [First Time Setup](#first-time-setup)
@@ -132,14 +134,14 @@ This will build the documentation and open it in your default browser.
 Run:
 
 ```shell
-./build_image.sh
+./scripts/build_image.sh
 ```
 
-This will create an image with the tag `anthonydickson/budgeteur:dev`.
+This will create an image with the tag `ghcr.io/anthonydickson/budgeteur:dev`.
 Run the server with:
 
 ```shell
-docker run --rm -p 3000:3000 -e SECRET=<YOUR-SECRET> -it anthonydickson/budgeteur:dev
+docker run --rm -p 8080:8080 -e SECRET=<YOUR-SECRET> -it ghcr.io/anthonydickson/budgeteur:dev
 ```
 
 > [!NOTE]


### PR DESCRIPTION
This PR extends the CSV import feature by adding support for the "simple" CSV export format from Kiwibank.
Commits:
- Parse Kiwibank "simple" csv exports
- Remove templates from Docker image
- Update instructions for running Docker image locally