### PR TITLE
Add CI/CD job to check Docker image build succeeds

### DIFF
--- a/.github/workflows/check-docker-build.yaml
+++ b/.github/workflows/check-docker-build.yaml
@@ -1,0 +1,27 @@
+name: Check Docker Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: anthonydickson/budgeteur
+
+jobs:
+  build-and-push-image:
+    name: Test Build Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Build and Push Docker Image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:test-${{ github.run_id }}-${{ github.run_attempt }}

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # To Do
 
-- Add CI/CD job on merge into main that checks that the Docker image can be built successfully.
+- Get hamburger menu working on mobile
 - Add screenshots of app in README.md
 - Add thousands separator to monetary amounts by implementing custom currency filter for Askama
 - Add thousands separator to timing durations (e.g., 1,234ms instead of 1234ms) for better readability


### PR DESCRIPTION
Past releases failed because of changes that caused the Docker image build to fail.
This PR adds a CI/CD pipeline job to ensure that the image can be built before merging into the main branch.