### PR TITLE
Remove support for full Kiwibank CSV

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,8 +13,6 @@
   - Extend to offer undo capabilities on delete/edit?
   - Review how HTML code is shared, `{{ foo|safe }}` vs `{% include foo.html %}` vs `{% call my_macro(...) %}`
 - Split up `src/transaction.rs` into module `src/transaction/*.rs`
-- Ensure that simple and full csv imports from Kiwibank do not create duplicate
-  transactions.
 - Create unique aliases of `i64` for each of the domain models, e.g., `Tag` -> `pub type TagID = i64;`.
 - Add edit and delete functionality for transactions.
 - Add full CRUD functionality for balances

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -56,17 +56,6 @@ pub fn parse_csv(text: &str) -> Result<ParseCSVResult, Error> {
         }
     }
 
-    let parse_result = parse_kiwibank_bank_csv(text);
-
-    match parse_result {
-        Ok(_) => {
-            return parse_result;
-        }
-        Err(error) => {
-            tracing::debug!("Could not parse Kiwibank bank statement: {error}");
-        }
-    }
-
     let parse_result = parse_kiwibank_bank_simple_csv(text);
 
     match parse_result {
@@ -370,102 +359,6 @@ fn parse_asb_cc_csv(text: &str) -> Result<ParseCSVResult, Error> {
     })
 }
 
-/// Parses detailed Kiwibank account CSV exported from form ib.kiwibank.co.nz.
-///
-/// Expects `text` to be a string containing comma separated values with lines separated by `\n`.
-///
-/// Returns a `ParseCSVResult` which consists of the transactions and account
-/// balances found in the CSV data.
-/// Returns `Error::InvalidCSV` if the CSV data is not in an accepted format.
-fn parse_kiwibank_bank_csv(text: &str) -> Result<ParseCSVResult, Error> {
-    // Header looks like:
-    // Account number,Date,Memo/Description,Source Code (payment type),TP ref,TP part,TP code,OP ref,OP part,OP code,OP name,OP Bank Account Number,Amount (credit),Amount (debit),Amount,Balance
-    const ACCOUNT_NUMBER_COLUMN: usize = 0;
-    const DATE_COLUMN: usize = 1;
-    const DESCRIPTION_COLUMN: usize = 2;
-    const AMOUNT_COLUMN: usize = 14;
-    const BALANCE_COLUMN: usize = 15;
-    const DATE_FORMAT: &[BorrowedFormatItem] = format_description!("[day]-[month]-[year]");
-
-    // Parse the header to get the account number
-    let lines = text.lines().collect::<Vec<_>>();
-
-    if lines.is_empty() {
-        return Err(Error::InvalidCSV("header too short".to_owned()));
-    }
-
-    let mut transactions = Vec::new();
-    let mut account_number = String::new();
-    let mut balance = 0.0;
-    let mut date = OffsetDateTime::now_utc().date();
-
-    for (line_number, line) in text.lines().enumerate() {
-        match line_number {
-            0 if line
-                != "Account number,Date,Memo/Description,Source Code (payment type),TP ref,TP part,TP code,OP ref,OP part,OP code,OP name,OP Bank Account Number,Amount (credit),Amount (debit),Amount,Balance" =>
-            {
-                return Err(Error::InvalidCSV(
-                    "Kiwibank bank statement missing header 'Account number,Date,Memo/Description,Source Code (payment type),TP ref,TP part,TP code,OP ref,OP part,OP code,OP name,OP Bank Account Number,Amount (credit),Amount (debit),Amount,Balance' on line 0"
-                        .to_owned(),
-                ));
-            }
-            _ if line_number > 0 => {
-                let parts: Vec<&str> = line.split(',').collect();
-
-                if parts.len() < 16 {
-                    continue;
-                }
-
-                account_number = parts[ACCOUNT_NUMBER_COLUMN].to_owned();
-                balance = parts[BALANCE_COLUMN].parse().map_err(|error| {
-                    Error::InvalidCSV(format!(
-                        "Could not parse '{}' as amount on line {line_number}: {error}",
-                        parts[BALANCE_COLUMN]
-                    ))
-                })?;
-                date = Date::parse(parts[DATE_COLUMN], &DATE_FORMAT).map_err(|error| {
-                    Error::InvalidCSV(format!(
-                        "Could not parse '{}' as date on line {line_number}: {error}",
-                        parts[DATE_COLUMN]
-                    ))
-                })?;
-                let description = parts[DESCRIPTION_COLUMN];
-                let description = description.trim_matches('"');
-                let description = description.trim_end_matches(" ;");
-                let amount: f64 = parts[AMOUNT_COLUMN].parse().map_err(|error| {
-                    Error::InvalidCSV(format!(
-                        "Could not parse '{}' as amount on line {line_number}: {error}",
-                        parts[AMOUNT_COLUMN]
-                    ))
-                })?;
-
-                let transaction = TransactionBuilder::new(amount)
-                    .date(date)
-                    .map_err(|error| {
-                        Error::InvalidCSV(format!(
-                            "Date '{}' on line {line_number} is invalid: {error}",
-                            parts[DATE_COLUMN]
-                        ))
-                    })?
-                    .description(description)
-                    .import_id(Some(create_import_id(line)));
-
-                transactions.push(transaction);
-            }
-            _ => {}
-        }
-    }
-
-    Ok(ParseCSVResult {
-        transactions,
-        balance: Some(ImportBalance {
-            account: account_number,
-            balance,
-            date,
-        }),
-    })
-}
-
 /// Parses simple Kiwibank account CSV exported from form ib.kiwibank.co.nz.
 ///
 /// Expects `text` to be a string containing comma separated values with lines separated by `\n`.
@@ -581,7 +474,7 @@ mod parse_csv_tests {
     use crate::{
         csv::{
             ImportBalance, ParseCSVResult, create_import_id, parse_asb_bank_csv,
-            parse_kiwibank_bank_csv, parse_kiwibank_bank_simple_csv,
+            parse_kiwibank_bank_simple_csv,
         },
         transaction::TransactionBuilder,
     };
@@ -614,14 +507,6 @@ mod parse_csv_tests {
         2025/04/10,2025/04/07,2025041001,DEBIT,5023,\"AMAZON DOWNLOADS TOKYO 862.00 YEN at a Conversion Rate  of 81.0913 (NZ$10.63)\",10.63\n\
         2025/04/10,2025/04/07,2025041002,DEBIT,5023,\"OFFSHORE SERVICE MARGINS\",0.22\n\
         2025/04/11,2025/04/10,2025041101,DEBIT,5023,\"Buckstars\",11.50";
-
-    const KIWIBANK_BANK_STATEMENT_CSV: &str = "Account number,Date,Memo/Description,Source Code (payment type),TP ref,TP part,TP code,OP ref,OP part,OP code,OP name,OP Bank Account Number,Amount (credit),Amount (debit),Amount,Balance\n\
-        38-1234-0123456-01,31-01-2025,INTEREST EARNED ;,,,,,,,,,,0.25,,0.25,71.16\n\
-        38-1234-0123456-01,31-01-2025,PIE TAX 10.500% ;,,,,,,,,,,,0.03,-0.03,71.13\n\
-        38-1234-0123456-01,28-02-2025,INTEREST EARNED ;,,,,,,,,,,0.22,,0.22,71.35\n\
-        38-1234-0123456-01,28-02-2025,PIE TAX 10.500% ;,,,,,,,,,,,0.02,-0.02,71.33\n\
-        38-1234-0123456-01,31-03-2025,INTEREST EARNED ;,,,,,,,,,,0.22,,0.22,71.55\n\
-        38-1234-0123456-01,31-03-2025,PIE TAX 10.500% ;,,,,,,,,,,,0.02,-0.02,71.53";
 
     const KIWIBANK_BANK_STATEMENT_SIMPLE_CSV: &str = "47-8115-1482616-00,,,,\n\
             22 Jan 2025,TRANSFER TO A R DICKSON - 01 ;,,-353.46,200.00\n\
@@ -851,75 +736,6 @@ mod parse_csv_tests {
         for (want, got) in want_transactions.iter().zip(&got_transactions) {
             assert_eq!(want, got);
         }
-        assert_eq!(want_transactions, got_transactions);
-        assert_eq!(want_balance, got_balance);
-    }
-
-    #[test]
-    fn can_parse_kiwibank_bank_statement() {
-        let want_transactions = vec![
-            TransactionBuilder::new(0.25)
-                .date(date!(2025 - 01 - 31))
-                .expect("Could not parse date")
-                .description("INTEREST EARNED")
-                .import_id(Some(create_import_id(
-                    "38-1234-0123456-01,31-01-2025,INTEREST EARNED ;,,,,,,,,,,0.25,,0.25,71.16",
-                ))),
-            TransactionBuilder::new(-0.03)
-                .date(date!(2025 - 01 - 31))
-                .expect("Could not parse date")
-                .description("PIE TAX 10.500%")
-                .import_id(Some(create_import_id(
-                    "38-1234-0123456-01,31-01-2025,PIE TAX 10.500% ;,,,,,,,,,,,0.03,-0.03,71.13",
-                ))),
-            TransactionBuilder::new(0.22)
-                .date(date!(2025 - 02 - 28))
-                .expect("Could not parse date")
-                .description("INTEREST EARNED")
-                .import_id(Some(create_import_id(
-                    "38-1234-0123456-01,28-02-2025,INTEREST EARNED ;,,,,,,,,,,0.22,,0.22,71.35",
-                ))),
-            TransactionBuilder::new(-0.02)
-                .date(date!(2025 - 02 - 28))
-                .expect("Could not parse date")
-                .description("PIE TAX 10.500%")
-                .import_id(Some(create_import_id(
-                    "38-1234-0123456-01,28-02-2025,PIE TAX 10.500% ;,,,,,,,,,,,0.02,-0.02,71.33",
-                ))),
-            TransactionBuilder::new(0.22)
-                .date(date!(2025 - 03 - 31))
-                .expect("Could not parse date")
-                .description("INTEREST EARNED")
-                .import_id(Some(create_import_id(
-                    "38-1234-0123456-01,31-03-2025,INTEREST EARNED ;,,,,,,,,,,0.22,,0.22,71.55",
-                ))),
-            TransactionBuilder::new(-0.02)
-                .date(date!(2025 - 03 - 31))
-                .expect("Could not parse date")
-                .description("PIE TAX 10.500%")
-                .import_id(Some(create_import_id(
-                    "38-1234-0123456-01,31-03-2025,PIE TAX 10.500% ;,,,,,,,,,,,0.02,-0.02,71.53",
-                ))),
-        ];
-
-        let want_balance = Some(ImportBalance {
-            account: "38-1234-0123456-01".to_owned(),
-            balance: 71.53,
-            date: date!(2025 - 03 - 31),
-        });
-
-        let ParseCSVResult {
-            transactions: got_transactions,
-            balance: got_balance,
-        } = parse_kiwibank_bank_csv(KIWIBANK_BANK_STATEMENT_CSV).expect("Could not parse CSV");
-
-        assert_eq!(
-            want_transactions.len(),
-            got_transactions.len(),
-            "want {} transactions, got {}",
-            want_transactions.len(),
-            got_transactions.len()
-        );
         assert_eq!(want_transactions, got_transactions);
         assert_eq!(want_balance, got_balance);
     }


### PR DESCRIPTION
Now only the "simple" format CSV files are supported. This will prevent potential duplicate entries from the two CSV formats.