### PR TITLE
Fix bug where imports would fail based on the time of day.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,8 +432,9 @@ dependencies = [
  "serde_html_form",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 2.0.16",
  "time",
+ "time-tz",
  "tokio",
  "tower-http",
  "tower-livereload",
@@ -821,7 +822,7 @@ dependencies = [
  "num",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.16",
  "typetag",
  "uuid",
 ]
@@ -1657,6 +1658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1714,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -1961,7 +1980,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21918d6644020c6f6ef1993242989bf6d4952d2e025617744f184c02df51c356"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2012,7 +2031,7 @@ dependencies = [
  "http",
  "mime",
  "rand 0.9.2",
- "thiserror",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -2087,6 +2106,18 @@ checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror 1.0.69",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2331,11 +2362,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2366,7 +2417,10 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -2387,6 +2441,22 @@ checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "time-tz"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733bc522e97980eb421cbf381160ff225bd14262a48a739110f6653c6258d625"
+dependencies = [
+ "cfg-if",
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+ "serde",
+ "serde-xml-rs",
+ "time",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3050,6 +3120,12 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ serde = { version = "1.0.227", features = ["derive"] }
 serde_json = "1.0.145"
 sha2 = { version = "0.10.9" }
 thiserror = "2.0.16"
-time = { version = "0.3.44", features = ["serde"] }
+time = { version = "0.3.44", features = ["serde", "local-offset"] }
+time-tz = "2.0.0"
 tokio = { version = "1.47.1", features = ["full"] }
 tower-http = { version = "0.6.6", features = ["trace", "fs"] }
 tower-livereload = "0.9.6" # For debug builds only

--- a/README.md
+++ b/README.md
@@ -164,3 +164,19 @@ docker run --rm -p 8080:8080 -e SECRET=<YOUR-SECRET> -it ghcr.io/anthonydickson/
 > [!NOTE]
 > Add `-v $(pwd):/app/data` to the above command (before `-it`) to persist
 > the app database after the container has stopped.
+
+## Dates and Timezones
+
+All dates and times shall use:
+
+1. the timezone specified in the CLI flags or
+1. the local timezone as specified by the host operating system or
+1. the UTC+00:00 timezone if the host operating system's local timezone cannot be determined.
+
+The app shall assume all dates and times from the web client use the timezone as determined above.
+
+The CLI shall accept canonical timezones as specified in <https://en.wikipedia.org/w/index.php?title=List_of_tz_database_time_zones&oldid=1309592143#List>
+
+### Limitations
+
+The timezone is only set when the server is started. You will have to restart the server to update the timezone for daylight savings.

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,6 +11,7 @@ services:
         --port 8080 
         --db-path /app/data/budgeteur.db
         --log-path /app/data/debug.log
+        --timezone Pacific/Auckland
     ports:
       # Change the port on the left if you want to change the port your PC
       # connects to.

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
 
           packages = with pkgs; [
             bacon
-            dockerfile-language-server-nodejs
+            dockerfile-language-server
             tailwindcss
             gemini-cli
           ];

--- a/src/log_out.rs
+++ b/src/log_out.rs
@@ -23,7 +23,7 @@ mod log_out_tests {
         cookie::{Cookie, Key},
     };
     use sha2::{Digest, Sha512};
-    use time::{Duration, OffsetDateTime};
+    use time::{Duration, OffsetDateTime, UtcOffset};
 
     use crate::{
         auth_cookie::{COOKIE_EXPIRY, COOKIE_USER_ID, DEFAULT_COOKIE_DURATION, set_auth_cookie},
@@ -34,8 +34,13 @@ mod log_out_tests {
 
     #[tokio::test]
     async fn log_out_invalidates_auth_cookie_and_redirects() {
-        let cookie_jar =
-            set_auth_cookie(get_jar(), UserID::new(123), DEFAULT_COOKIE_DURATION).unwrap();
+        let cookie_jar = set_auth_cookie(
+            get_jar(),
+            UserID::new(123),
+            DEFAULT_COOKIE_DURATION,
+            UtcOffset::UTC,
+        )
+        .unwrap();
 
         let response = get_log_out(cookie_jar).await;
 

--- a/templates/partials/dashboard/transaction_with_tags.html
+++ b/templates/partials/dashboard/transaction_with_tags.html
@@ -3,11 +3,11 @@
     scope="row"
     class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white"
   >
-    {{ transaction.id() }}
+    {{ transaction.id }}
   </th>
-  <td class="px-6 py-4 text-right">${{ "{:.0}"|format(transaction.amount()) }}</td>
-  <td class="px-6 py-4">{{ transaction.date() }}</td>
-  <td class="px-6 py-4">{{ transaction.description() }}</td>
+  <td class="px-6 py-4 text-right">${{ "{:.0}"|format(transaction.amount) }}</td>
+  <td class="px-6 py-4">{{ transaction.date }}</td>
+  <td class="px-6 py-4">{{ transaction.description }}</td>
   <td class="px-6 py-4">
     {% if let Some(error) = tag_error %}
       <span class="text-red-600 dark:text-red-400 text-xs">Error: {{ error }}</span>


### PR DESCRIPTION
This bug was caused by the discrepancy between the server date (UTC) and
the local time (inputs from the client).
When the transaction builder was called in the import process, the server
date was one day behind the current local date, causing transactions for
the current local date being rejected as "future dates".

Changes:
- Add CLI argument to specify timezone and add timezone to app state.
- Use local time when getting current time.
- Refactor interface for `Transaction` and `TransactionBuilder`.
  Removes most of the accessor functions and shifts
  validation of dates to `TransactionBuilder::finalize(..)`.