### PR TITLE
feat: Replace cookie-based auth expiry with server-side sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,65 +1,166 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
+## Project Overview
 
-- `src/` contains the Rust application code, split into feature modules (e.g., `account/`, `transaction/`, `tag/`, `rule/`, `dashboard/`) plus `bin/` entry points (`server`, `create_test_db`, `reset_password`).
-- `static/` holds built web assets (for example, `static/main.css` from Tailwind).
-- `assets/` stores documentation images.
-- `migrations/` contains database migration scripts.
-- `docs/` holds design and technical specs; `DOCS.md` is the developer guide.
-- `scripts/` contains helper scripts such as `build_image.sh`.
+Budgeteur is a personal finance web app built with Rust (Axum + Maud + HTMX) backed by SQLite. It serves HTML pages directly (MPA with HTMX for interactivity). Single binary `server` handles everything; no JavaScript build step.
 
 ## Build, Test, and Development Commands
 
-- `nix develop` to enter the pinned dev environment (Rust toolchain, bacon, Tailwind, test env vars).
-- `cargo run --bin create_test_db -- --output-path test.db` to create a local test database (first time).
-- `bacon` to run the watch task runner; press `r` to run the server, `t` to run tests, `d` to build docs.
-- `cargo test` to run the full test suite outside bacon.
-- `./scripts/build_image.sh` to build the Docker image, then `docker run --rm -p 8080:8080 -e SECRET=<YOUR-SECRET> -it ghcr.io/anthonydickson/budgeteur:dev`.
+- `nix develop` — enter dev shell (Rust 1.95, bacon, Tailwind v4, `SECRET` env var).
+- `cargo run --bin create_test_db -- --output-path test.db` — create a local test database (first time only).
+- `bacon` — watch task runner. Press `r` to run the server, `t` to run tests, `c` for clippy-all, `f` for format, `d` for docs. See `bacon.toml` for all jobs.
+- `cargo test` — run full test suite standalone.
+- `cargo test -q && cargo clippy -q && cargo fmt` — final quality check before committing.
+- `dprint fmt` — format Markdown and other non-Rust files.
+- `./scripts/build_image.sh` — build Docker image, then `docker run --rm -p 8080:8080 -e SECRET=<YOUR-SECRET> -it ghcr.io/anthonydickson/budgeteur:dev`.
+- Server binary flags: `--db-path`, `--timezone`, `--address`, `--port`, `--log-path` (see `src/bin/server.rs:27-49`).
 
-## Coding Style & Naming Conventions
+## Project Structure & Architecture
 
-- Follow Rust standard style: `snake_case` for functions/variables, `PascalCase` for types.
-- Prefer a simple and functional programming style.
-- Avoid adding abstraction unless it would significantly reduce the amount of code to write, improve readability, make
-  the code easier to reason about or make the project easier to maintain and extend.
-- Avoid comments that just restate what the code is doing, focus on comments that explain unintuitive code, rationale
-  or important invariants.
-- Prefer imports at the top of the file over inline, qualified imports
-- When acquiring the shared DB connection in handlers, avoid `unwrap()`; log lock errors and return `Error::DatabaseLockError`.
-- Prefer `Error`’s `IntoResponse` for page endpoints; insert errors into forms or use `AlertTemplate` for fragments.
-- Use `bacon.toml` jobs for quality checks (`cargo check`, `cargo clippy`, `cargo doc`).
+```
+src/
+  bin/
+    server.rs          # Entry point: parses CLI, sets up tracing, session actor, router
+    create_test_db.rs  # Creates test.db with all tables
+    reset_password.rs  # CLI tool for password resets
+  lib.rs               # Re-exports AppState, Error, build_router, initialize_db, etc.
+  app_state.rs         # AppState: cookie_key, db_connection (Arc<Mutex<Connection>>), session_actor, scheduler
+  routing.rs           # build_router(): unprotected routes, protected GET routes (auth_guard), protected mutating routes (auth_guard_hx)
+  endpoints.rs         # All route path constants + format_endpoint() helper
+  error.rs             # App-level Error enum with IntoResponse (page errors) and into_alert_response() (fragment errors)
+  db.rs                # initialize() creates all tables in a single transaction
+  html.rs              # Shared Maud components: base(), error_view(), form styles, buttons, currency formatting
+  alert.rs             # Alert enum (Success/Error) rendered as OOB HTMX swap into #alert-container
+  logging.rs           # Request/response logging middleware that redacts passwords
+  navigation.rs        # NavBar struct → bottom nav (mobile) + sidebar (desktop)
+  timezone.rs          # get_local_offset() for timezone-aware date handling
+  input.css            # Tailwind CSS input
+  account/             # CRUD pages + endpoints
+  auth/                # Login, logout, forgot password, middleware, cookie handling, sessions
+  csv_import/          # CSV file upload + transaction import
+  dashboard/           # Dashboard views: cards, charts, tables, aggregation
+  rule/                # CRUD for auto-tagging rules
+  tag/                 # CRUD for tags, excluded tags, preferences
+  transaction/         # Core transaction logic, CRUD pages/endpoints, quick tagging, form rendering
+    quick_tagging/     # Sub-module: HTMX-driven quick tagging workflow for untagged imports
+  test_utils/          # Shared test helpers: form assertions, HTML parsing, HTTP response helpers
+migrations/            # SQL migration scripts for schema upgrades
+static/                # Built assets: main.css (Tailwind output), HTMX JS, ECharts JS, favicons
+docs/                  # Design and tech spec documents
+```
 
-## Testing Guidelines
+### Control Flow
 
-- Tests live alongside code in `src/` modules with `#[cfg(test)]` and `#[test]`/`#[tokio::test]`.
-- Run via `bacon` (`t`) or `cargo test`. Database-related tests often rely on `test.db`.
+1. `server.rs` parses CLI args, opens SQLite, initializes DB tables, starts Kameo session/scheduler actors, builds router with `build_router(state)`.
+2. `routing.rs` splits routes into unprotected (login, forgot password, coffee) and protected (everything else). Protected GET routes use `auth_guard` (redirect on failure). Protected POST/PUT/DELETE routes use `auth_guard_hx` (HxRedirect on failure).
+3. Each feature module follows the same pattern: `mod.rs` re-exports, `core.rs` for models/DB queries, `*_page.rs` for GET handlers + HTML rendering, `*_endpoint.rs` for POST/PUT/DELETE handlers.
 
-## View Templates & Test Helpers
+### Session Architecture
 
-- Keep `html!` blocks presentation-focused by preparing values above the markup; for example, precompute a `TransactionFormDefaults` before rendering and pass it into a shared helper.
-- When the same form appears in multiple pages, extract a shared renderer (e.g., transaction form fields live in `src/transaction/form.rs` and are reused by create/edit views).
-- Prefer shared test helpers for repeated HTML assertions (e.g., `src/transaction/test_utils.rs` centralizes HTML parsing and form input checks).
-- For new form fields, add a minimal regression test that asserts the input exists and the default selected/checked state (e.g., transaction `type_` radio inputs).
+- `auth/session.rs` implements an in-memory `SessionStore` actor via [Kameo](https://github.com/tqwewe/kameo). Sessions have idle timeout (15 min) and max age (24 hours). A `Scheduler` actor periodically clears expired sessions.
+- `AppState` holds `ActorRef<SessionStore>` and `ActorRef<Scheduler>`. The session actor is started in `server.rs` via `start_session_actor()` and passed into `AppState::new()`.
+- `auth/middleware.rs` extracts the session ID from the cookie, calls `Extend` on the session actor (atomic verify + idle-bump), and redirects to login on `None`.
+- The cookie carries `Token { session_id: Uuid }` — an opaque UUID v4, no user ID or expiry. The cookie expires at `MAX_SESSION_AGE` (24h); no middleware cookie-extension logic.
+- See `docs/session-auth.md` for the full design.
 
-## Commit & Pull Request Guidelines
+## State Extraction Pattern
 
-- Commit messages follow a conventional pattern like `feat: ...` or `refactor: ...` (often with a PR number, e.g., `(#99)`).
-- PRs should include a clear description, link relevant issues if any, and add screenshots for UI changes.
-- Ensure tests pass and update docs/specs when behavior or UI changes.
+Handlers extract state via `FromRef` implementations on per-endpoint state structs:
 
-## Security & Configuration Tips
+```rust
+#[derive(Debug, Clone)]
+pub struct CreateAccountState {
+    pub db_connection: Arc<Mutex<Connection>>,
+}
 
-- For local development, use the `SECRET` environment variable (provided by `nix develop` or manually).
-- The default server runs on HTTP; use a reverse proxy for HTTPS in real deployments.
+impl FromRef<AppState> for CreateAccountState {
+    fn from_ref(state: &AppState) -> Self {
+        Self { db_connection: state.db_connection.clone() }
+    }
+}
+```
 
-## Date/Time Conventions
+Never extract `Arc<Mutex<Connection>>` directly from `AppState` — create a dedicated state struct. When acquiring the lock, never `unwrap()`; log the error and return `Error::DatabaseLockError`.
 
-- Prefer explicit window presets (week/fortnight/month/quarter/half-year/year) for date-range navigation and include full four-digit years on both ends of range labels.
-- Default “now” calculations to the user’s local timezone via `get_local_offset`, not UTC.
-- For windowed navigation, use target date ranges as link text to make direction unambiguous.
+## Error Handling
 
-## Dev Process
+Two response paths depending on context:
 
-- When finished implementing or refactoring something, run `cargo test -q`, `cargo clippy -q` and `cargo fmt`.
-- When replacing a subsystem (e.g., pagination → windows), remove unused modules/tests rather than silencing dead-code warnings.
+- **Page endpoints** (full page responses): Implement `IntoResponse` for `Error`. Most errors map to `InternalServerError` or `NotFoundError` templates. The `?` operator works directly in handlers returning `impl IntoResponse`.
+
+- **Fragment endpoints** (HTMX responses): Call `error.into_alert_response()` which returns `(StatusCode, Alert::into_html())`. The Alert renders as an OOB swap into `#alert-container` (defined in `base()` template).
+
+- Always log errors at the callsite: `tracing::error!("Could not create account: {error}");`
+
+- DB locking pattern (always use this):
+  ```rust
+  let connection = match state.db_connection.lock() {
+      Ok(conn) => conn,
+      Err(error) => {
+          tracing::error!("could not acquire database lock: {error}");
+          return Error::DatabaseLockError.into_alert_response();
+      }
+  };
+  ```
+
+- Success responses for mutating endpoints: return `(HxRedirect(target), StatusCode::SEE_OTHER).into_response()`.
+
+## Testing Patterns
+
+- Tests live alongside code with `#[cfg(test)]` and `#[test]`/`#[tokio::test]`.
+- Database tests use `Connection::open_in_memory()` + `initialize(&conn)` for a fresh SQLite instance per test.
+- Standard pattern for endpoint tests:
+  ```rust
+  fn get_test_connection() -> Connection {
+      let conn = Connection::open_in_memory().unwrap();
+      initialize(&conn).unwrap();
+      conn
+  }
+  ```
+- Handler tests call the handler function directly with `State(state)` + `Form(form)` and inspect the response.
+- Integration-style tests use `axum-test::TestServer` with `Router::new()`.
+- `src/test_utils/` provides shared helpers:
+  - `form::` — `must_get_form()`, `assert_form_input()`, `assert_form_input_with_value()`, `assert_form_submit_button()`, `assert_hx_endpoint()`, `assert_form_error_message()` (all use `scraper` crate)
+  - `html::` — `parse_html_document()`, `parse_html_fragment()`, `assert_valid_html()`
+  - `http::` — `assert_status_ok()`, `assert_content_type()`, `get_header()`, `assert_hx_redirect()`
+- Module-specific test utils (e.g., `transaction/test_utils.rs`) provide domain assertions like `assert_transaction_type_inputs()`.
+- When adding form fields, add a regression test asserting the input exists with correct default/checked state.
+
+## Templating (Maud + HTMX)
+
+- Use `maud::html!` macro for all HTML rendering. Keep `html!` blocks presentation-focused: precompute values above the template.
+- All pages use `html::base(title, &head_elements, &content)` which provides DOCTYPE, HTMX scripts, favicon, alert container, and body styles.
+- `HEAD` elements (scripts, styles) are passed as `&[HeadElement]` — use `HeadElement::ScriptLink()`, `HeadElement::ScriptSource()`, `HeadElement::Style()`.
+- CSS classes are defined as `&str` constants in `html.rs` (e.g., `FORM_TEXT_INPUT_STYLE`, `TABLE_ROW_STYLE`). Use these constants, don't inline Tailwind classes.
+- HTMX attributes: `hx-post`, `hx-put`, `hx-delete`, `hx-target`, `hx-swap`, `hx-confirm`, `hx-target-error="#alert-container"` (for fragment-alert error responses).
+- Reusable form components should be extracted into shared renderers (e.g., `transaction/form.rs`).
+- Currency formatting: use `html::format_currency()` (2 decimal places) or `html::format_currency_rounded()` (whole dollars). The `numfmt` crate loses trailing zeros — `format_currency()` manually appends them.
+
+## Coding Style & Conventions
+
+- Rust 2024 edition. `snake_case` for functions/variables, `PascalCase` for types.
+- Prefer imports at top of file; avoid inline qualified imports.
+- Avoid abstraction unless it meaningfully reduces code volume or improves readability/reasoning.
+- No comments that restate code; only document non-obvious rationale, invariants, or gotchas.
+- Use `tracing` (not `log`) for all logging.
+- Date/time: use `time` crate (not `chrono`). Default to user's local timezone via `get_local_offset()`, not UTC.
+- When replacing subsystems, delete unused modules/tests — never silence dead-code warnings.
+- Try to follow the functional core, imperative shell pattern. Business logic should mostly live in the functional core
+  and sources of non-deterministic behaviour such as reading the system time, generating random data, I/O should live
+  outside the core.
+
+## Commit & PR Guidelines
+
+- Commit messages: `feat: ...`, `fix: ...`, `refactor: ...`, `chore: ...` — often with PR number suffix e.g. `(#99)`.
+- PRs: clear description, link issues, screenshots for UI changes.
+- Ensure tests pass and update docs/specs.
+
+## Important Gotchas
+
+- **Safari localhost**: Secure cookies on localhost don't work in Safari. Use Chrome/Firefox for local testing.
+- **Cookie path**: Always set `.path("/")` on auth cookies to avoid browser omitting cookies for parent paths.
+- **HTMX redirects vs regular redirects**: Protected GET routes use `Redirect` (303). Protected POST/PUT/DELETE routes must use `HxRedirect` for HTMX to follow the redirect. This is why `routing.rs` has two separate `protected_routes` blocks with different middleware.
+- **numfmt trailing zeros**: `numfmt::Formatter::currency()` drops the last trailing zero (e.g., `$12.30` → `$12.3`). `format_currency()` manually appends `"0"` when needed.
+- **SQLite locking**: DB connection is `Arc<Mutex<Connection>>`. Always handle lock errors, never `unwrap()`.
+- **Rust edition 2024**: The project uses edition 2024 — some syntax differs from 2021 (e.g., `use` ordering, `unsafe` blocks).
+- **Markdown formatting**: After editing any Markdown file, run `dprint fmt` to format it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,8 @@ dependencies = [
  "charming",
  "clap",
  "csv",
+ "kameo",
+ "kameo_actors",
  "maud",
  "md5",
  "numfmt",
@@ -372,6 +374,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-segmentation",
+ "uuid",
  "zxcvbn",
 ]
 
@@ -818,6 +821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
 name = "dtoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,12 +996,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "futures"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1002,16 +1027,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-sink"
-version = "0.3.31"
+name = "futures-macro"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -1025,8 +1072,11 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1086,6 +1136,12 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -1512,6 +1568,46 @@ checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kameo"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1dfd134d7a2c6ec05ee696dcbf3f7a034bdb97ecc623e981014652dcd124d77"
+dependencies = [
+ "downcast-rs",
+ "dyn-clone",
+ "futures",
+ "kameo_macros",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "kameo_actors"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220bdd75769f0a9b752a91123e58bf42f595e3c36ff4b13818d7a87d962076e6"
+dependencies = [
+ "futures",
+ "glob",
+ "kameo",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "kameo_macros"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c9002c9ecd16e1636f566c0bf62db48e70d86ed0d0a91b398955e883217a23"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2853,6 +2949,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -3130,11 +3227,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ bcrypt = "0.19.0"
 charming = "0.6.0"
 clap = { version = "4.6.1", features = ["derive"] }
 csv = "1.4.0"
+kameo = "0.20.0"
+kameo_actors = "0.5.0"
 maud = { version = "0.27.0", features = ["axum"] }
 md5 = "0.8.0"
 numfmt = "1.2.0"
@@ -36,6 +38,7 @@ tower-livereload = "0.10.3" # For debug builds only
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 unicode-segmentation = "1.13.2"
+uuid = { version = "1.23.1", features = ["serde", "v4"] }
 zxcvbn = "3.1.1"
 
 [dev-dependencies]

--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,6 @@
 
 ## Side Quest: Multi-Client Support (TUI)
 
-- Session actor and proper sessions instead of token just holding the user ID
-  - Use [Kameo](https://github.com/tqwewe/kameo)
 - Reorganise project into workspaces?
   - server: Existing HTMX MPA + new JSON API layer
     - current `src/` folder

--- a/docs/auth-redirect-tech-spec.md
+++ b/docs/auth-redirect-tech-spec.md
@@ -11,6 +11,7 @@ Preserve the user's previous page when automatic logout occurs, so after re-auth
 - Covers log-in page rendering and log-in POST redirect target selection.
 
 Out of scope:
+
 - Manual log out flow (`GET /api/log_out`) remains unchanged.
 - Cross-origin or external redirects are not supported.
 

--- a/docs/navigation-design-spec.md
+++ b/docs/navigation-design-spec.md
@@ -7,6 +7,7 @@ Define the current navigation design and implementation for Budgeteur.
 ## Current Design
 
 ### Information Architecture
+
 - Primary destinations: Dashboard, Transactions, Accounts, Tags, Rules, Log out.
 - Navigation is global and appears at the top of each authenticated page.
 - Primary destinations expose contextual actions via dropdowns (desktop) or expandable menus (mobile).
@@ -21,6 +22,7 @@ Define the current navigation design and implementation for Budgeteur.
 - Do not move empty-state links.
 
 ### Desktop Layout
+
 - Top navigation bar with logo on the left and horizontal links on the right.
 - Each primary destination with a submenu uses a toggle interaction; clicking the primary label opens/closes the submenu (no navigation).
 - Hovering (or keyboard focus) reveals a dropdown panel anchored to the nav item.
@@ -29,6 +31,7 @@ Define the current navigation design and implementation for Budgeteur.
 - Active link is visually highlighted.
 
 ### Mobile/Tablet Layout
+
 - Top header (logo/title) stays at the top.
 - Primary navigation moves to a fixed bottom bar.
 - Tapping a nav item toggles its submenu, which expands upward from the bar.
@@ -36,11 +39,13 @@ Define the current navigation design and implementation for Budgeteur.
 - The submenu includes the main page link first, followed by contextual actions.
 
 ### Visual Style
+
 - Light theme uses white backgrounds and gray borders; dark theme uses dark backgrounds and muted text.
 - Active state uses blue highlight.
 - Uses Tailwind utility classes for spacing, typography, and colors.
 
 ### Accessibility
+
 - Bottom nav uses `aria-current="page"` for the active item.
 - Dropdowns are keyboard accessible (Tab order; no arrow key handling required).
 - Links use normal anchor semantics.
@@ -48,12 +53,14 @@ Define the current navigation design and implementation for Budgeteur.
 ## Current Implementation
 
 ### Markup and Rendering
+
 - Navigation is rendered by `NavBar` in `src/navigation.rs`.
 - `NavBar::new(active_endpoint)` builds a fixed list of `Link` items.
 - The active link is determined by comparing the current endpoint to the link URL.
 - The logout link is never marked as active.
 
 ### Structure
+
 - Top-level `<nav>` contains:
   - Brand/logo link to `/`.
   - Desktop links container with `ul > li > a` shown from `lg` and up.
@@ -61,11 +68,13 @@ Define the current navigation design and implementation for Budgeteur.
 - Link styles include active and inactive variants with `lg:` overrides for desktop.
 
 ### Interaction
+
 - Desktop: hover or focus reveals dropdown menus; click toggles the submenu when one exists.
 - Mobile/tablet: tap toggles the submenu; only one submenu should be open at a time.
 - Tapping/clicking outside an open submenu closes it.
 
 ### Call Sites
+
 - `NavBar` is included in most page templates, e.g.
   - `src/dashboard/handlers.rs`
   - `src/transaction/transactions_page.rs` (via `transactions_view`)
@@ -84,16 +93,19 @@ Define the current navigation design and implementation for Budgeteur.
   - `src/rule/edit.rs`
 
 ### Goals
+
 - Keep the current desktop navigation style and behavior for main links.
 - Centralize contextual actions inside the main navigation (dropdowns/expanders).
 - Maintain the bottom navigation bar on mobile/tablet, with upward-expanding submenus.
 - Style the bottom bar similar to “example 6” from Justinmind’s mobile navigation article.
 
 ### Breakpoints
+
 - Bottom nav is shown for widths < 1024px.
 - Existing top nav is shown at ≥ 1024px.
 
 ### Bottom Navigation (Tablet/Phone)
+
 - Fixed bar at the bottom of the viewport.
 - Always show four items (fixed set):
   - Dashboard, Transactions, Accounts, More.
@@ -114,17 +126,20 @@ Define the current navigation design and implementation for Budgeteur.
 - Preserve dark/light theme parity.
 
 ### Layout Adjustments
+
 - Add safe-area spacing and bottom padding to main content so fixed bottom nav does not obscure page content.
 - Remove or hide the hamburger button and collapsible top menu on tablet/phone sizes.
 - Keep the top header (logo/title) visible on tablet/phone; only the nav links move to the bottom bar.
 
 ### Accessibility
+
 - Add `aria-current="page"` on the active bottom nav item.
 - Keep link text visible (not icon-only) for clarity and touch targets.
 - Ensure submenu toggles are keyboard accessible.
 - When a hidden item is the active page, highlight “More” in the bar and mark the hidden item as active in the submenu.
 
 ### Implementation Notes
+
 - Extend `NavBar` to render two nav variants:
   - Desktop top nav (existing structure + dropdown menus).
   - Mobile/tablet bottom nav (upward-expanding submenus).
@@ -138,6 +153,7 @@ Define the current navigation design and implementation for Budgeteur.
 - Ensure `static/app.js` does not conflict with the new layout (hamburger may be removed or hidden on small screens).
 
 ## Implementation Decisions (Ad-Hoc)
+
 - **Bottom nav styling:** Container uses `rounded-xl`; pill buttons use `rounded-lg` for a slightly tighter look.
 - **Bottom nav width/gutters:** Wrapper uses `max-w-screen-xl` with a consistent `px-4` gutter to match page containers on landscape.
 - **Z-index layering:** Bottom nav uses `z-40` so it sits above page content but below alerts.
@@ -146,6 +162,7 @@ Define the current navigation design and implementation for Budgeteur.
 - **Chart height responsiveness:** Dashboard chart containers use `min-h-[240px] sm:min-h-[300px] md:min-h-[340px] lg:min-h-[380px]` to keep axis labels visible on small/landscape screens.
 
 ### Future Enhancement (Optional)
+
 - Consider progressively revealing hidden items inline on tablet widths, and hiding “More” when there is sufficient space.
 
 ---

--- a/docs/session-auth.md
+++ b/docs/session-auth.md
@@ -1,0 +1,84 @@
+# Session-Based Authentication
+
+Server-side sessions via the Kameo `SessionStore` actor. The cookie carries an
+opaque session ID (UUID v4); the server validates and manages the session
+lifecycle.
+
+## Auth Lifecycle
+
+```
+  Log In
+  ├─ Verify password
+  ├─ Session::new() → session_id (UUID v4)
+  ├─ SessionStore::Set { id, issued_at, expires_at }
+  ├─ Set cookie: auth_token = { session_id }
+  └─ Redirect to dashboard
+
+  Authenticated Request
+  ├─ Extract session_id from cookie
+  ├─ SessionStore::Extend { session_id }              ← verify + bump idle timer
+  │  ├─ Some(session) → continue
+  │  └─ None → redirect to /login                     ← expired or missing
+  └─ Response (pass-through, no cookie manipulation)
+
+  Log Out
+  ├─ Extract session_id from cookie
+  ├─ SessionStore::Delete { session_id }
+  ├─ Invalidate cookie
+  └─ Redirect to /login
+```
+
+## Session Lifecycle
+
+| Event                 | Behavior                                                                      |
+| --------------------- | ----------------------------------------------------------------------------- |
+| Created (login)       | `issued_at = now`, `expires_at = now + IDLE_TIMEOUT` (15 min)                 |
+| Extend (each request) | `expires_at = min(now + IDLE_TIMEOUT, issued_at + MAX_SESSION_AGE)` (max 24h) |
+| Scheduler (hourly)    | Removes all sessions where `expires_at < now`                                 |
+
+Cookie expires at `MAX_SESSION_AGE` (24h). The server manages session expiry
+independently; the cookie just needs to outlive the session.
+
+## Key Files
+
+| File                     | Role                                                                                                           |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `src/auth/session.rs`    | `Session` struct, `SessionStore` actor, messages (`Set`, `Extend`, `Delete`, `ClearExpiredSessions`) |
+| `src/auth/token.rs`      | `Token { session_id: Uuid }` — serialized into the auth cookie                                                 |
+| `src/auth/cookie.rs`     | `set_auth_cookie()`, `invalidate_auth_cookie()`, `get_token_from_cookies()`                                    |
+| `src/auth/middleware.rs` | `auth_guard` / `auth_guard_hx` — extracts session ID, calls `Extend`, redirects on `None`                      |
+| `src/auth/log_in.rs`     | `post_log_in` — verifies password, creates session, sets cookie                                                |
+| `src/auth/log_out.rs`    | `get_log_out` — deletes session from actor, invalidates cookie                                                 |
+
+## Design Decisions
+
+1. **Session ID format** — UUID v4 (`uuid` crate). Strong randomness, minimal
+   overhead.
+
+2. **No `user_id` in sessions** — this is a single-user application. The
+   `Session` struct carries only `id`, `issued_at`, and `expires_at`.
+
+3. **No request extension** — `UserID` is not inserted into request extensions
+   because no handler reads it. If a handler needs the user ID in future, it
+   can use `UserID::new(1)` directly.
+
+4. **Cookie duration** — matches `MAX_SESSION_AGE` (24h). No middleware
+   cookie-extension logic. The cookie is set once at login; the browser sends it
+   on every request until it expires.
+
+5. **"Remember me"** — dropped. Single session length: `IDLE_TIMEOUT` 15 min,
+   `MAX_SESSION_AGE` 24h.
+
+6. **Atomic verify + extend** — the middleware calls `Extend` as a single
+   message rather than `Verify` then `Extend`. This avoids a TOCTOU race where
+   the session could expire between the two calls.
+
+7. **Expired session cleanup** — the middleware does not clear cookies on
+   `None` (expired/missing session). The login handler sets a fresh cookie on
+   successful login, overwriting any stale one. The `ClearExpiredSessions`
+   scheduler removes dead sessions from the actor every hour.
+
+8. **Multiple concurrent sessions** — supported by the actor (map-based, no
+   uniqueness constraint). Moot for a single-user app. If concurrent access
+   becomes relevant, a session-listing endpoint or "log out everywhere" feature
+   would be needed.

--- a/docs/transaction-table-tech-spec.md
+++ b/docs/transaction-table-tech-spec.md
@@ -24,10 +24,10 @@ Grouping is layered rather than mutually exclusive:
    - The smallest interval size is weekly; daily intervals are not a supported mode.
 
 2. **Category Summary (Grouped Totals, optional)**
-    - Within each date interval, show a category breakdown list (tag totals + % of total income/expenses).
-    - Income categories are ordered by total descending; expense categories are ordered by absolute total descending.
-    - Include an “Other” row for `None` tags.
-    - Each category row can expand to reveal transactions grouped by day using the same transaction row layout.
+   - Within each date interval, show a category breakdown list (tag totals + % of total income/expenses).
+   - Income categories are ordered by total descending; expense categories are ordered by absolute total descending.
+   - Include an “Other” row for `None` tags.
+   - Each category row can expand to reveal transactions grouped by day using the same transaction row layout.
 
 The UI can toggle the category summary layer on/off without changing the underlying query semantics.
 

--- a/docs/untagged-transactions-tech-spec.md
+++ b/docs/untagged-transactions-tech-spec.md
@@ -26,6 +26,7 @@ Define the design and behavior for a queue of imported transactions that remain 
 - Foreign key: `transaction_id REFERENCES "transaction"(id) ON DELETE CASCADE`
 
 Rationale:
+
 - Primary key ensures a single queue row per transaction.
 - `created_at` supports ordering the queue by most recently added.
 - `ON DELETE CASCADE` makes queue cleanup automatic when a transaction is deleted.

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,9 @@
+{
+  "markdown": {
+  },
+  "includes": ["**/*.md"],
+  "excludes": [],
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.21.1.wasm"
+  ]
+}

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -2,13 +2,13 @@
 
 use std::sync::{Arc, Mutex};
 
+use crate::auth::SessionStore;
 use axum::extract::FromRef;
 use axum_extra::extract::cookie::Key;
+use kameo::actor::ActorRef;
+use kameo_actors::scheduler::Scheduler;
 use rusqlite::Connection;
 use sha2::{Digest, Sha512};
-use time::Duration;
-
-use crate::auth::DEFAULT_COOKIE_DURATION;
 
 /// The state of the REST server.
 #[derive(Debug, Clone)]
@@ -16,28 +16,39 @@ pub struct AppState {
     /// The key to be used for signing and encrypting private cookies.
     pub cookie_key: Key,
 
-    /// The duration for which cookies used for authentication are valid.
-    pub cookie_duration: Duration,
-
     /// The local timezone as a canonical timezone name, e.g. "Pacific/Auckland".
     pub local_timezone: String,
 
     /// The database connection
     pub db_connection: Arc<Mutex<Connection>>,
+
+    /// An in-memory store for managing sessions
+    pub session_actor: ActorRef<SessionStore>,
+
+    /// An actor that schedules messages to actors. Primarily for clearing the
+    /// session store at a fixed interval.
+    pub scheduler: ActorRef<Scheduler>,
 }
 
 impl AppState {
     /// Create a new [AppState] with a SQLite database connection.
     ///
     /// `local_timezone` should be a valid, canonical timezone name, e.g. "Pacific/Auckland".
-    pub fn new(db_connection: Connection, cookie_secret: &str, local_timezone: &str) -> Self {
+    pub fn new(
+        db_connection: Connection,
+        cookie_secret: &str,
+        local_timezone: &str,
+        session_actor: ActorRef<SessionStore>,
+        scheduler: ActorRef<Scheduler>,
+    ) -> Self {
         let connection = Arc::new(Mutex::new(db_connection));
 
         Self {
             cookie_key: create_cookie_key(cookie_secret),
-            cookie_duration: DEFAULT_COOKIE_DURATION,
             local_timezone: local_timezone.to_owned(),
             db_connection: connection,
+            session_actor,
+            scheduler,
         }
     }
 }

--- a/src/auth/cookie.rs
+++ b/src/auth/cookie.rs
@@ -1,46 +1,35 @@
 //! Defines functions for handling user authentication with cookies.
 
-use std::cmp::max;
-
 use axum_extra::extract::{
     PrivateCookieJar,
     cookie::{Cookie, SameSite},
 };
-use time::{Duration, OffsetDateTime, UtcOffset};
+use time::{Duration, OffsetDateTime};
 
 use crate::{
     Error,
-    auth::{Token, UserID},
+    auth::{SessionId, Token},
 };
 
 /// The name of the cookie that will hold the auth token.
 pub const COOKIE_TOKEN: &str = "auth_token";
-/// The default duration for which auth cookies are valid.
-pub const DEFAULT_COOKIE_DURATION: Duration = Duration::minutes(5);
 
-/// Add an auth token to the cookie jar, indicating that a user is logged in and authenticated.
-///
-/// Sets the initial expiry of the cookie to `duration` from the current time.
-/// You can use [COOKIE_DURATION] for the default duration.
+/// Add a session token to the cookie jar, indicating that a user is logged in
+/// and authenticated.
 ///
 /// Returns the cookie jar with the cookie added.
 ///
 /// # Errors
 ///
-/// Returns a [Error::JSONSerializationError] if the expiry time cannot be formatted.
+/// Returns an [Error::JSONSerializationError] if the session ID cannot be
+/// serialized.
 pub fn set_auth_cookie(
     jar: PrivateCookieJar,
-    user_id: UserID,
-    duration: Duration,
-    local_timezone: UtcOffset,
+    session_id: SessionId,
+    expiry: OffsetDateTime,
 ) -> Result<PrivateCookieJar, Error> {
-    let expiry = OffsetDateTime::now_utc().to_offset(local_timezone) + duration;
-
     let token = {
-        let token = Token {
-            user_id,
-            expires_at: expiry,
-        };
+        let token = Token { session_id };
 
         serde_json::to_string(&token)
             .map_err(|err| Error::JSONSerializationError(err.to_string()))?
@@ -52,10 +41,10 @@ pub fn set_auth_cookie(
             .http_only(true)
             .same_site(SameSite::Strict)
             .secure(true)
-            // Explicitly set path to root to avoid issues with subpaths. For example, if the
-            // cookie is set from a subpath such as 'http://example.com/path1/path2', the
-            // browser will not send the cookie in requests for parent paths such as
-            // 'http://example.com/path1'.
+            // Explicitly set path to root to avoid issues with subpaths.
+            // For example, if the cookie is invalidated from a subpath such
+            // as 'http://example.com/api/logout', the browser will not
+            // invalidate the cookie for 'http://example.com/path1'.
             .path("/"),
     ))
 }
@@ -76,72 +65,6 @@ pub fn invalidate_auth_cookie(jar: PrivateCookieJar) -> PrivateCookieJar {
             // invalidate the cookie for 'http://example.com/path1'.
             .path("/"),
     )
-}
-
-/// Set the expiry of the auth cookie in `jar` to the latest of UTC now
-/// plus `duration` and the cookie's expiry.
-///
-/// # Errors
-///
-/// The cookie jar is not modified if an error is returned.
-///
-/// Returns:
-/// - [Error::CookieMissing] if the auth cookie or expiry cookie are not in the cookie jar.
-/// - [Error::InvalidDateFormat] if the new expiry date time cannot be formatted.
-///
-/// # Panics
-///
-/// Panics if adding `duration` to the current time overflows.
-/// See [time::Date::MAX] for more information.
-pub fn extend_auth_cookie_duration_if_needed(
-    jar: PrivateCookieJar,
-    duration: Duration,
-    local_timezone: UtcOffset,
-) -> Result<PrivateCookieJar, Error> {
-    let token = get_token_from_cookies(&jar)?;
-    let new_expiry = OffsetDateTime::now_utc().to_offset(local_timezone) + duration;
-    let expiry = max(token.expires_at, new_expiry);
-
-    set_auth_cookie_expiry(jar, expiry)
-}
-
-/// Sets the expires field of the auth cookie and the expires field and
-/// value of the expiry cookie in `jar` to `expiry`.
-///
-/// # Errors
-///
-/// If an error is returned, the cookie jar is not modified.
-///
-/// Returns a:
-/// - [Error::CookieMissing] if the auth cookie or expiry cookie are not in the cookie jar.
-/// - [Error::InvalidDateFormat] if the new expiry date time cannot be formatted.
-pub fn set_auth_cookie_expiry(
-    jar: PrivateCookieJar,
-    expiry: OffsetDateTime,
-) -> Result<PrivateCookieJar, Error> {
-    let mut token_cookie = jar.get(COOKIE_TOKEN).ok_or(Error::CookieMissing)?;
-
-    let token: Token = serde_json::from_str(token_cookie.value_trimmed())
-        .map_err(|err| Error::JSONSerializationError(err.to_string()))?;
-
-    let updated_token_string = serde_json::to_string(&Token {
-        user_id: token.user_id,
-        expires_at: expiry,
-    })
-    .map_err(|err| Error::JSONSerializationError(err.to_string()))?;
-
-    token_cookie.set_expires(expiry);
-    token_cookie.set_value(updated_token_string);
-
-    // Need to set the secure, http_only, and same_site flags again since they
-    // are not set in requests from clients (clients only send the
-    // key-value pair).
-    token_cookie.set_http_only(true);
-    token_cookie.set_same_site(SameSite::Strict);
-    token_cookie.set_secure(true);
-    token_cookie.set_path("/");
-
-    Ok(jar.add(token_cookie))
 }
 
 /// Extract the token from the token cookie.
@@ -167,147 +90,55 @@ mod tests {
         cookie::{Key, SameSite},
     };
     use sha2::{Digest, Sha512};
-    use time::{Duration, OffsetDateTime, UtcOffset};
+    use time::{Duration, OffsetDateTime};
+    use uuid::Uuid;
 
     use crate::{
         Error,
-        auth::{
-            COOKIE_TOKEN, DEFAULT_COOKIE_DURATION, Token, UserID, invalidate_auth_cookie,
-            set_auth_cookie,
-        },
+        auth::{COOKIE_TOKEN, SessionId, invalidate_auth_cookie, set_auth_cookie},
     };
 
-    use super::{
-        extend_auth_cookie_duration_if_needed, get_token_from_cookies, set_auth_cookie_expiry,
-    };
+    use super::get_token_from_cookies;
 
     #[test]
     fn can_set_cookie() {
-        let expected_token = Token {
-            user_id: UserID::new(1),
-            expires_at: OffsetDateTime::now_utc() + DEFAULT_COOKIE_DURATION,
-        };
+        let session_id = Uuid::new_v4();
         let jar = get_jar();
 
         let jar = set_auth_cookie(
             jar,
-            expected_token.user_id,
-            DEFAULT_COOKIE_DURATION,
-            UtcOffset::UTC,
+            session_id,
+            OffsetDateTime::now_utc() + Duration::hours(24),
         )
         .unwrap();
 
-        assert_auth_cookies_eq(jar, &expected_token);
+        assert_auth_cookies_eq(jar, session_id);
     }
 
     #[test]
     fn can_get_token_from_cookies() {
-        let expected = Token {
-            user_id: UserID::new(1),
-            expires_at: OffsetDateTime::now_utc() + DEFAULT_COOKIE_DURATION,
-        };
+        let session_id = Uuid::new_v4();
         let jar = set_auth_cookie(
             get_jar(),
-            expected.user_id,
-            DEFAULT_COOKIE_DURATION,
-            UtcOffset::UTC,
+            session_id,
+            OffsetDateTime::now_utc() + Duration::hours(24),
         )
         .unwrap();
 
         let actual = get_token_from_cookies(&jar).unwrap();
 
-        assert_eq!(actual.user_id, expected.user_id);
-        assert_date_time_close(expected.expires_at, actual.expires_at);
-    }
-
-    #[test]
-    fn can_set_cookie_expires() {
-        let expected = Token {
-            user_id: UserID::new(1),
-            expires_at: OffsetDateTime::now_utc() + Duration::days(10),
-        };
-        let jar = get_jar();
-        let jar = set_auth_cookie(
-            jar,
-            expected.user_id,
-            DEFAULT_COOKIE_DURATION,
-            UtcOffset::UTC,
-        )
-        .unwrap();
-
-        let updated_jar = set_auth_cookie_expiry(jar, expected.expires_at).unwrap();
-
-        assert_auth_cookies_eq(updated_jar, &expected);
-    }
-
-    #[test]
-    fn can_extend_cookie_duration() {
-        let user_id = UserID::new(1);
-        let jar = get_jar();
-        let jar = set_auth_cookie(jar, user_id, DEFAULT_COOKIE_DURATION, UtcOffset::UTC).unwrap();
-        let initial_token = get_token_from_cookies(&jar).unwrap();
-        let expected = Token {
-            user_id,
-            expires_at: initial_token.expires_at + DEFAULT_COOKIE_DURATION,
-        };
-
-        let jar = extend_auth_cookie_duration_if_needed(jar, Duration::minutes(10), UtcOffset::UTC)
-            .unwrap();
-
-        assert_auth_cookies_eq(jar, &expected);
-    }
-
-    #[test]
-    fn sets_secure_httponly_samesite_flags_if_missing() {
-        let user_id = UserID::new(1);
-        let jar = get_jar();
-        let jar = set_auth_cookie(jar, user_id, DEFAULT_COOKIE_DURATION, UtcOffset::UTC).unwrap();
-        let initial_token = get_token_from_cookies(&jar).unwrap();
-        let expected = Token {
-            user_id,
-            expires_at: initial_token.expires_at + DEFAULT_COOKIE_DURATION,
-        };
-        for mut cookie in jar.iter() {
-            cookie.set_secure(false);
-            cookie.set_http_only(false);
-            cookie.set_same_site(SameSite::None);
-        }
-
-        let jar = extend_auth_cookie_duration_if_needed(jar, Duration::minutes(10), UtcOffset::UTC)
-            .unwrap();
-
-        assert_auth_cookies_eq(jar, &expected);
-    }
-
-    #[test]
-    fn cookie_duration_does_not_change() {
-        let expected = Token {
-            user_id: UserID::new(1),
-            expires_at: OffsetDateTime::now_utc() + DEFAULT_COOKIE_DURATION,
-        };
-        let jar = set_auth_cookie(
-            get_jar(),
-            expected.user_id,
-            DEFAULT_COOKIE_DURATION,
-            UtcOffset::UTC,
-        )
-        .unwrap();
-        let stale_cookie = jar.get(COOKIE_TOKEN).unwrap();
-        let want = Some(stale_cookie.expires_datetime().unwrap());
-
-        // The initial cookie is set to expire in 5 minutes, so extending it by 5 seconds should not change the expiry.
-        let jar = extend_auth_cookie_duration_if_needed(jar, Duration::seconds(5), UtcOffset::UTC)
-            .unwrap();
-
-        let cookie = jar.get(COOKIE_TOKEN).unwrap();
-        assert_eq!(cookie.expires_datetime(), want);
+        assert_eq!(actual.session_id, session_id);
     }
 
     #[test]
     fn invalidate_auth_cookie_succeeds() {
-        let user_id = UserID::new(1);
-        let jar =
-            set_auth_cookie(get_jar(), user_id, DEFAULT_COOKIE_DURATION, UtcOffset::UTC).unwrap();
+        let session_id = Uuid::new_v4();
+        let jar = set_auth_cookie(
+            get_jar(),
+            session_id,
+            OffsetDateTime::now_utc() + Duration::hours(24),
+        )
+        .unwrap();
 
         let jar = invalidate_auth_cookie(jar);
         let cookie = jar.get(COOKIE_TOKEN).unwrap();
@@ -330,26 +161,11 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_date_time_close(expected: OffsetDateTime, actual: OffsetDateTime) {
-        assert!(
-            (expected - actual).abs() < Duration::seconds(1),
-            "got date time {:?}, want {:?}",
-            actual,
-            expected
-        );
-    }
-
-    #[track_caller]
-    fn assert_auth_cookies_eq(jar: PrivateCookieJar, expected_token: &Token) {
+    fn assert_auth_cookies_eq(jar: PrivateCookieJar, expected_session_id: SessionId) {
         let token_cookie = jar.get(COOKIE_TOKEN).unwrap();
         let actual_token = get_token_from_cookies(&jar).unwrap();
 
-        assert_eq!(actual_token.user_id, expected_token.user_id);
-        assert_date_time_close(actual_token.expires_at, expected_token.expires_at);
-        assert_date_time_close(
-            token_cookie.expires_datetime().unwrap(),
-            expected_token.expires_at,
-        );
+        assert_eq!(actual_token.session_id, expected_session_id);
         assert_eq!(token_cookie.http_only(), Some(true));
         assert_eq!(token_cookie.same_site(), Some(SameSite::Strict));
         assert_eq!(token_cookie.secure(), Some(true));

--- a/src/auth/log_in.rs
+++ b/src/auth/log_in.rs
@@ -11,21 +11,22 @@ use axum::{
 };
 use axum_extra::extract::{PrivateCookieJar, cookie::Key};
 use axum_htmx::HxRedirect;
+use kameo::actor::ActorRef;
 use maud::{Markup, html};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
-use time::Duration;
+use time::{OffsetDateTime, UtcDateTime};
 
 use crate::{
     AppState, Error,
     app_state::create_cookie_key,
     auth::{
-        DEFAULT_COOKIE_DURATION, User, UserID, get_user_by_id, invalidate_auth_cookie,
-        normalize_redirect_url, set_auth_cookie,
+        SessionStore, User, UserID, get_user_by_id, invalidate_auth_cookie, normalize_redirect_url,
+        session::{MAX_SESSION_AGE, Session, Set},
+        set_auth_cookie,
     },
     endpoints,
     html::{BUTTON_PRIMARY_STYLE, base, loading_spinner, password_input},
-    timezone::get_local_offset,
 };
 
 fn contianer(form_title: &str, form: &Markup) -> Markup {
@@ -67,23 +68,6 @@ fn log_in_form(password: &str, error_message: Option<&str>, redirect_url: Option
             }
 
             (password_input(password, 0, error_message, true))
-
-            div class="flex items-center gap-x-3"
-            {
-                input
-                    type="checkbox"
-                    name="remember_me"
-                    id="remember_me"
-                    tabindex="0"
-                    class="rounded-xs";
-
-                label
-                    for="remember_me"
-                    class="block text-sm font-medium text-gray-900 dark:text-white"
-                {
-                    "Keep me logged in for one week"
-                }
-            }
 
             button
                 type="submit" id="submit-button" tabindex="0"
@@ -131,33 +115,26 @@ pub async fn get_log_in_page(Query(query): Query<RedirectQuery>) -> Response {
     base("Log In", &[], &content).into_response()
 }
 
-/// How long the auth cookie should last if the user selects "remember me" at log-in.
-const REMEMBER_ME_COOKIE_DURATION: Duration = Duration::days(7);
-
 /// The state needed to perform a login.
 #[derive(Debug, Clone)]
 pub struct LoginState {
     /// The key to be used for signing and encrypting private cookies.
     pub cookie_key: Key,
-    /// The duration for which cookies used for authentication are valid.
-    pub cookie_duration: Duration,
-    /// The local timezone as a canonical timezone name, e.g. "Pacific/Auckland".
-    pub local_timezone: String,
     pub db_connection: Arc<Mutex<Connection>>,
+    pub session_actor: ActorRef<SessionStore>,
 }
 
 impl LoginState {
-    /// Create the cookie key from a string and set the default cookie duration.
+    /// Create the cookie key from a string.
     pub fn new(
         cookie_secret: &str,
-        local_timezone: &str,
         db_connection: Arc<Mutex<Connection>>,
+        session_actor: ActorRef<SessionStore>,
     ) -> Self {
         Self {
             cookie_key: create_cookie_key(cookie_secret),
-            cookie_duration: DEFAULT_COOKIE_DURATION,
-            local_timezone: local_timezone.to_owned(),
-            db_connection: db_connection.clone(),
+            db_connection,
+            session_actor,
         }
     }
 }
@@ -166,9 +143,8 @@ impl FromRef<AppState> for LoginState {
     fn from_ref(state: &AppState) -> Self {
         Self {
             cookie_key: state.cookie_key.clone(),
-            cookie_duration: state.cookie_duration,
-            local_timezone: state.local_timezone.clone(),
             db_connection: state.db_connection.clone(),
+            session_actor: state.session_actor.clone(),
         }
     }
 }
@@ -184,18 +160,15 @@ pub const INVALID_CREDENTIALS_ERROR_MSG: &str = "Incorrect password.";
 
 /// Handler for log-in requests via the POST method.
 ///
-/// On a successful log-in request, the auth cookie set and the client is redirected to the dashboard page.
-/// Otherwise, the form is returned with an error message explaining the problem.
-///
-/// # Errors
-///
-/// This function will return an error in a few situations.
-/// - The password is not correct.
-/// - An internal error occurred when verifying the password.
+/// On a successful log-in request, a session is created, the auth cookie is
+/// set and the client is redirected.
+/// Otherwise, the form is returned with an error message explaining the
+/// problem.
 ///
 /// # Panics
 ///
-/// Panics if the lock for the database connection is already held by the same thread.
+/// Panics if the lock for the database connection is already held by the same
+/// thread.
 pub async fn post_log_in(
     State(state): State<LoginState>,
     jar: PrivateCookieJar,
@@ -247,20 +220,30 @@ pub async fn post_log_in(
         return log_in_form("", Some(INVALID_CREDENTIALS_ERROR_MSG), redirect_url).into_response();
     }
 
-    let cookie_duration = if user_data.remember_me.is_some() {
-        REMEMBER_ME_COOKIE_DURATION
-    } else {
-        state.cookie_duration
-    };
+    let now = UtcDateTime::now();
+    let session = Session::new(now);
 
-    let local_timezone = match get_local_offset(&state.local_timezone) {
-        Some(offset) => offset,
-        None => return Error::InvalidTimezoneError(state.local_timezone).into_response(),
-    };
+    if let Err(err) = state
+        .session_actor
+        .tell(Set {
+            session: session.clone(),
+        })
+        .await
+    {
+        tracing::error!("Error creating session: {err}");
+        return log_in_form(
+            "",
+            Some("An internal error occurred. Please try again later."),
+            redirect_url,
+        )
+        .into_response();
+    }
 
     let redirect_url = redirect_url.unwrap_or(endpoints::DASHBOARD_VIEW);
 
-    set_auth_cookie(jar.clone(), user.id, cookie_duration, local_timezone)
+    let cookie_expiry: OffsetDateTime = (now + MAX_SESSION_AGE).into();
+
+    set_auth_cookie(jar.clone(), session.id, cookie_expiry)
         .map(|updated_jar| {
             (
                 StatusCode::SEE_OTHER,
@@ -285,21 +268,10 @@ pub struct RedirectQuery {
 }
 
 /// The raw data entered by the user in the log-in form.
-///
-/// The password is stored as a plain string. There is no need for validation here since
-/// it will be compared against the password in the database, which has been verified.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct LogInData {
     /// Password entered during log-in.
     pub password: String,
-
-    /// Whether to extend the initial auth cookie duration.
-    ///
-    /// This value comes from a checkbox, so it either has a string value or is not set
-    /// (see the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#value_2)).
-    /// The `Some` variant should be interpreted as `true` irregardless of the
-    /// string value, and the `None` variant should be interpreted as `false`.
-    pub remember_me: Option<String>,
 
     /// Optional URL to redirect to after logging in.
     /// Only accepted from the log-in form submission.
@@ -320,9 +292,11 @@ mod log_in_page_tests {
         http::{StatusCode, header::CONTENT_TYPE},
     };
     use axum_extra::extract::PrivateCookieJar;
+    use kameo::actor::Spawn;
     use rusqlite::Connection;
 
     use crate::{
+        auth::SessionStore,
         auth::user::create_user_table,
         endpoints,
         test_utils::{assert_valid_html, parse_html_document, parse_html_fragment},
@@ -401,7 +375,6 @@ mod log_in_page_tests {
         let jar = PrivateCookieJar::new(state.cookie_key.clone());
         let form = LogInData {
             password: "wrongpassword".to_string(),
-            remember_me: None,
             redirect_url: None,
         };
         let response = post_log_in(State(state), jar, Form(form)).await;
@@ -469,7 +442,11 @@ mod log_in_page_tests {
                 .expect("Could not create test user");
         }
 
-        LoginState::new("foobar", "Etc/UTC", Arc::new(Mutex::new(connection)))
+        LoginState::new(
+            "foobar",
+            Arc::new(Mutex::new(connection)),
+            SessionStore::spawn(SessionStore::new()),
+        )
     }
 
     #[track_caller]
@@ -503,20 +480,16 @@ mod log_in_tests {
     use axum_extra::extract::{PrivateCookieJar, cookie::Cookie};
     use axum_htmx::HX_REDIRECT;
     use axum_test::TestServer;
-
+    use kameo::actor::Spawn;
     use rusqlite::Connection;
-    use time::{Duration, OffsetDateTime};
 
     use crate::{
         PasswordHash, ValidatedPassword,
-        auth::{COOKIE_TOKEN, User, UserID, create_user_table},
+        auth::{COOKIE_TOKEN, SessionStore, User, UserID, create_user_table},
         endpoints,
     };
 
-    use super::{
-        INVALID_CREDENTIALS_ERROR_MSG, LogInData, LoginState, REMEMBER_ME_COOKIE_DURATION,
-        post_log_in,
-    };
+    use super::{INVALID_CREDENTIALS_ERROR_MSG, LogInData, LoginState, post_log_in};
 
     #[tokio::test]
     async fn log_in_succeeds_with_valid_credentials() {
@@ -533,7 +506,6 @@ mod log_in_tests {
             state,
             LogInData {
                 password: "test".to_string(),
-                remember_me: None,
                 redirect_url: None,
             },
         )
@@ -559,7 +531,6 @@ mod log_in_tests {
             state,
             LogInData {
                 password: "test".to_string(),
-                remember_me: None,
                 redirect_url: Some(redirect_url.to_string()),
             },
         )
@@ -583,28 +554,12 @@ mod log_in_tests {
             state,
             LogInData {
                 password: "test".to_string(),
-                remember_me: None,
                 redirect_url: Some("https://example.com".to_string()),
             },
         )
         .await;
 
         assert_hx_redirect(&response, endpoints::DASHBOARD_VIEW);
-    }
-
-    /// Test helper macro to assert that two date times are within one second
-    /// of each other. Used instead of a function so that the file and line
-    /// number of the caller is included in the error message instead of the
-    /// helper.
-    macro_rules! assert_date_time_close {
-        ($left:expr, $right:expr$(,)?) => {
-            assert!(
-                ($left - $right).abs() < Duration::seconds(2),
-                "got date time {:?}, want {:?}",
-                $left,
-                $right
-            );
-        };
     }
 
     #[tokio::test]
@@ -625,47 +580,6 @@ mod log_in_tests {
 
     #[tokio::test]
     async fn form_deserialises() {
-        let state = get_test_app_config(None);
-        let app = Router::new()
-            .route(endpoints::LOG_IN_API, post(post_log_in))
-            .with_state(state);
-        let server = TestServer::new(app);
-        let form = [("password", "test"), ("remember_me", "on")];
-
-        let response = server.post(endpoints::LOG_IN_API).form(&form).await;
-
-        assert_ne!(response.status_code(), StatusCode::UNPROCESSABLE_ENTITY);
-    }
-
-    #[tokio::test]
-    async fn remember_me_extends_auth_cookie_through_form() {
-        let state = get_test_app_config(Some(&User {
-            id: UserID::new(1),
-            password_hash: PasswordHash::new(
-                ValidatedPassword::new_unchecked("test"),
-                PasswordHash::DEFAULT_COST,
-            )
-            .expect("Could not create test user"),
-        }));
-        let app = Router::new()
-            .route(endpoints::LOG_IN_API, post(post_log_in))
-            .with_state(state);
-        let server = TestServer::new(app);
-        let form = [("password", "test"), ("remember_me", "on")];
-
-        let response = server.post(endpoints::LOG_IN_API).form(&form).await;
-
-        assert_eq!(response.status_code(), StatusCode::SEE_OTHER);
-
-        let token_cookie = response.cookie(COOKIE_TOKEN);
-        assert_date_time_close!(
-            token_cookie.expires_datetime().unwrap(),
-            OffsetDateTime::now_utc() + REMEMBER_ME_COOKIE_DURATION
-        );
-    }
-
-    #[tokio::test]
-    async fn form_deserialises_without_remember_me() {
         let state = get_test_app_config(None);
         let app = Router::new()
             .route(endpoints::LOG_IN_API, post(post_log_in))
@@ -693,7 +607,6 @@ mod log_in_tests {
             state,
             LogInData {
                 password: "wrongpassword".to_string(),
-                remember_me: None,
                 redirect_url: None,
             },
         )
@@ -718,7 +631,11 @@ mod log_in_tests {
                 .expect("Could not create test user");
         }
 
-        LoginState::new("foobar", "Etc/UTC", Arc::new(Mutex::new(connection)))
+        LoginState::new(
+            "foobar",
+            Arc::new(Mutex::new(connection)),
+            SessionStore::spawn(SessionStore::new()),
+        )
     }
 
     async fn new_log_in_request(state: LoginState, log_in_form: LogInData) -> Response<Body> {
@@ -745,7 +662,7 @@ mod log_in_tests {
 
             match cookie.name() {
                 COOKIE_TOKEN => {
-                    assert!(cookie.expires_datetime() > Some(OffsetDateTime::now_utc()));
+                    assert!(cookie.expires_datetime() > Some(time::OffsetDateTime::now_utc()));
                     found_cookies.insert(cookie.name().to_string());
                 }
                 _ => panic!("Unexpected cookie found: {}", cookie.name()),

--- a/src/auth/log_out.rs
+++ b/src/auth/log_out.rs
@@ -1,12 +1,46 @@
-//! Log-out route handler that invalidates authentication cookies and redirects users.
+//! Log-out route handler that invalidates sessions and clears authentication cookies.
 
-use axum::response::{IntoResponse, Redirect, Response};
+use axum::{
+    extract::{FromRef, State},
+    response::{IntoResponse, Redirect, Response},
+};
 use axum_extra::extract::PrivateCookieJar;
+use kameo::actor::ActorRef;
 
-use crate::{auth::invalidate_auth_cookie, endpoints};
+use crate::{
+    AppState,
+    auth::{SessionStore, cookie::get_token_from_cookies, invalidate_auth_cookie, session::Delete},
+    endpoints,
+};
 
-/// Invalidate the auth cookie and redirect the client to the log-in page.
-pub async fn get_log_out(jar: PrivateCookieJar) -> Response {
+/// The state needed for logging out.
+#[derive(Debug, Clone)]
+pub struct LogoutState {
+    /// An in-memory store for managing sessions
+    pub session_actor: ActorRef<SessionStore>,
+}
+
+impl FromRef<AppState> for LogoutState {
+    fn from_ref(state: &AppState) -> Self {
+        Self {
+            session_actor: state.session_actor.clone(),
+        }
+    }
+}
+
+/// Invalidate the session and auth cookie, then redirect to the log-in page.
+pub async fn get_log_out(State(state): State<LogoutState>, jar: PrivateCookieJar) -> Response {
+    if let Ok(token) = get_token_from_cookies(&jar)
+        && let Err(err) = state
+            .session_actor
+            .tell(Delete {
+                id: token.session_id,
+            })
+            .await
+    {
+        tracing::error!("Error deleting session: {err}");
+    }
+
     let jar = invalidate_auth_cookie(jar);
 
     (jar, Redirect::to(endpoints::LOG_IN_VIEW)).into_response()
@@ -16,31 +50,47 @@ pub async fn get_log_out(jar: PrivateCookieJar) -> Response {
 mod log_out_tests {
     use axum::{
         body::Body,
+        extract::State,
         http::{Response, StatusCode, header::SET_COOKIE},
     };
     use axum_extra::extract::{
         PrivateCookieJar,
         cookie::{Cookie, Key},
     };
+    use kameo::actor::Spawn;
     use sha2::{Digest, Sha512};
-    use time::{Duration, OffsetDateTime, UtcOffset};
+    use time::{Duration, OffsetDateTime, UtcDateTime};
 
     use crate::{
-        auth::{COOKIE_TOKEN, DEFAULT_COOKIE_DURATION, UserID, get_log_out, set_auth_cookie},
+        auth::{
+            COOKIE_TOKEN, SessionStore, get_log_out,
+            log_out::LogoutState,
+            session::{Session, Set},
+            set_auth_cookie,
+        },
         endpoints,
     };
 
     #[tokio::test]
     async fn log_out_invalidates_auth_cookie_and_redirects() {
+        let session = Session::new(UtcDateTime::now());
+        let session_actor = SessionStore::spawn(SessionStore::new());
+        session_actor
+            .tell(Set {
+                session: session.clone(),
+            })
+            .await
+            .unwrap();
+
         let cookie_jar = set_auth_cookie(
             get_jar(),
-            UserID::new(123),
-            DEFAULT_COOKIE_DURATION,
-            UtcOffset::UTC,
+            session.id,
+            OffsetDateTime::now_utc() + time::Duration::hours(24),
         )
         .unwrap();
+        let state = LogoutState { session_actor };
 
-        let response = get_log_out(cookie_jar).await;
+        let response = get_log_out(State(state), cookie_jar).await;
 
         assert_redirect(&response, endpoints::LOG_IN_VIEW);
         assert_cookie_expired(&response);

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -1,24 +1,22 @@
-//! Authentication middleware that validates cookies, extends sessions, and handles redirects.
+//! Authentication middleware that validates cookies, verifies sessions, and handles redirects.
 
 use axum::{
     extract::{FromRef, FromRequestParts, Request, State},
-    http::{StatusCode, header::SET_COOKIE},
     middleware::Next,
     response::{IntoResponse, Redirect, Response},
 };
 use axum_extra::extract::{PrivateCookieJar, cookie::Key};
 use axum_htmx::HxRedirect;
-use time::Duration;
+use kameo::actor::ActorRef;
+use time::UtcDateTime;
 
 use crate::{
     AppState,
     auth::{
-        build_log_in_redirect_url,
-        cookie::{extend_auth_cookie_duration_if_needed, get_token_from_cookies},
-        redirect::build_log_in_redirect_url_from_target,
+        SessionStore, build_log_in_redirect_url, cookie::get_token_from_cookies,
+        redirect::build_log_in_redirect_url_from_target, session::Extend,
     },
     endpoints,
-    timezone::get_local_offset,
 };
 
 /// The state needed for the auth middleware
@@ -26,18 +24,15 @@ use crate::{
 pub struct AuthState {
     /// The key to be used for signing and encrypting private cookies.
     pub cookie_key: Key,
-    /// The duration for which cookies used for authentication are valid.
-    pub cookie_duration: Duration,
-    /// The local timezone as a canonical timezone name, e.g. "Pacific/Auckland".
-    pub local_timezone: String,
+    /// An in-memory store for managing sessions
+    pub session_actor: ActorRef<SessionStore>,
 }
 
 impl FromRef<AppState> for AuthState {
     fn from_ref(state: &AppState) -> Self {
         Self {
             cookie_key: state.cookie_key.clone(),
-            cookie_duration: state.cookie_duration,
-            local_timezone: state.local_timezone.clone(),
+            session_actor: state.session_actor.clone(),
         }
     }
 }
@@ -49,12 +44,8 @@ impl FromRef<AuthState> for Key {
     }
 }
 
-/// Middleware function that checks for a valid authorization cookie.
-/// The user ID is placed into request and then the request executed normally if the cookie is valid, otherwise a redirect to the log-in page is returned using `get_redirect`.
-///
-/// **Note**: Route handlers can use the function argument `Extension(user_id): Extension<UserID>` to receive the user ID.
-///
-/// **Note**: The app state must contain an `axum_extra::extract::cookie::Key` for decrypting and verifying the cookie contents.
+/// Middleware function that checks for a valid authorization cookie and
+/// verifies the session via the session actor.
 #[inline]
 async fn auth_guard_internal(
     state: AuthState,
@@ -74,13 +65,6 @@ async fn auth_guard_internal(
         build_log_in_redirect_url_from_target(endpoints::DASHBOARD_VIEW)
             .unwrap_or_else(|| endpoints::LOG_IN_VIEW.to_owned())
     });
-    let local_offset = match get_local_offset(&state.local_timezone) {
-        Some(offset) => offset,
-        None => {
-            tracing::error!("Error getting local timezone. Redirecting to log in page.");
-            return get_redirect(&log_in_redirect_url);
-        }
-    };
 
     let (mut parts, body) = request.into_parts();
     let jar = match PrivateCookieJar::from_request_parts(&mut parts, &state).await {
@@ -90,44 +74,37 @@ async fn auth_guard_internal(
             return get_redirect(&log_in_redirect_url);
         }
     };
-    let user_id = match get_token_from_cookies(&jar) {
-        Ok(token) => token.user_id,
+    let token = match get_token_from_cookies(&jar) {
+        Ok(token) => token,
         Err(_) => return get_redirect(&log_in_redirect_url),
     };
 
-    parts.extensions.insert(user_id);
-    let request = Request::from_parts(parts, body);
-    let response = next.run(request).await;
-
-    let (mut parts, body) = response.into_parts();
-    let jar = match extend_auth_cookie_duration_if_needed(
-        jar.clone(),
-        Duration::minutes(5),
-        local_offset,
-    ) {
-        Ok(updated_jar) => updated_jar,
+    match state
+        .session_actor
+        .ask(Extend {
+            id: token.session_id,
+            now: UtcDateTime::now(),
+        })
+        .await
+    {
+        Ok(Some(_session)) => {
+            let request = Request::from_parts(parts, body);
+            next.run(request).await
+        }
+        Ok(None) => {
+            tracing::debug!("Session expired or missing. Redirecting to log in.");
+            get_redirect(&log_in_redirect_url)
+        }
         Err(err) => {
-            tracing::error!("Error extending cookie duration: {err:?}. Rolling back cookie jar.");
-            jar
+            tracing::error!("Error communicating with session actor: {err:?}");
+            get_redirect(&log_in_redirect_url)
         }
-    };
-    for (key, val) in jar.into_response().headers().iter() {
-        if key != SET_COOKIE {
-            continue;
-        }
-
-        parts.headers.append(key, val.to_owned());
     }
-
-    Response::from_parts(parts, body)
 }
 
 /// Middleware function that checks for a valid authorization cookie.
-/// The user ID is placed into request and then the request executed normally if the cookie is valid, otherwise a redirect to the log-in page is returned.
-///
-/// **Note**: Route handlers can use the function argument `Extension(user_id): Extension<UserID>` to receive the user ID.
-///
-/// **Note**: The app state must contain an `axum_extra::extract::cookie::Key` for decrypting and verifying the cookie contents.
+/// The request is executed normally if the session is valid, otherwise a
+/// redirect to the log-in page is returned.
 pub async fn auth_guard(State(state): State<AuthState>, request: Request, next: Next) -> Response {
     auth_guard_internal(state, request, next, |redirect_url| {
         Redirect::to(redirect_url).into_response()
@@ -136,18 +113,19 @@ pub async fn auth_guard(State(state): State<AuthState>, request: Request, next: 
 }
 
 /// Middleware function that checks for a valid authorization cookie.
-/// The user ID is placed into request and then the request executed normally if the cookie is valid, otherwise a HTMX redirect to the log-in page is returned.
-///
-/// **Note**: Route handlers can use the function argument `Extension(user_id): Extension<UserID>` to receive the user ID.
-///
-/// **Note**: The app state must contain an `axum_extra::extract::cookie::Key` for decrypting and verifying the cookie contents.
+/// The request is executed normally if the session is valid, otherwise an
+/// HTMX redirect to the log-in page is returned.
 pub async fn auth_guard_hx(
     State(state): State<AuthState>,
     request: Request,
     next: Next,
 ) -> Response {
     auth_guard_internal(state, request, next, |redirect_url| {
-        (HxRedirect(redirect_url.to_owned()), StatusCode::OK).into_response()
+        (
+            HxRedirect(redirect_url.to_owned()),
+            axum::http::StatusCode::OK,
+        )
+            .into_response()
     })
     .await
 }
@@ -163,20 +141,22 @@ mod auth_guard_tests {
     };
     use axum_extra::extract::{
         PrivateCookieJar,
-        cookie::{Cookie, Key, SameSite},
+        cookie::{Cookie, Key},
     };
     use axum_test::TestServer;
+    use kameo::actor::Spawn;
     use sha2::Digest;
-    use time::{Duration, OffsetDateTime};
+    use time::{Duration, OffsetDateTime, UtcDateTime};
 
     use crate::{
         Error,
         auth::{
-            AuthState, COOKIE_TOKEN, DEFAULT_COOKIE_DURATION, UserID, auth_guard, auth_guard_hx,
+            COOKIE_TOKEN, SessionStore, auth_guard, auth_guard_hx,
+            middleware::AuthState,
+            session::{Session, Set},
             set_auth_cookie,
         },
         endpoints::{self, format_endpoint},
-        timezone::get_local_offset,
     };
 
     async fn test_handler() -> Html<&'static str> {
@@ -187,21 +167,37 @@ mod auth_guard_tests {
         State(state): State<AuthState>,
         jar: PrivateCookieJar,
     ) -> Result<PrivateCookieJar, Error> {
-        let local_timezone = get_local_offset(&state.local_timezone).unwrap();
+        let session = Session::new(UtcDateTime::now());
 
-        set_auth_cookie(jar, UserID::new(1), state.cookie_duration, local_timezone)
+        state
+            .session_actor
+            .tell(Set {
+                session: session.clone(),
+            })
+            .await
+            .map_err(|err| {
+                Error::JSONSerializationError(format!(
+                    "Could not communicate with session actor: {err}"
+                ))
+            })?;
+
+        set_auth_cookie(
+            jar,
+            session.id,
+            OffsetDateTime::now_utc() + Duration::hours(24),
+        )
     }
 
     const TEST_LOG_IN_ROUTE_PATH: &str = "/log_in/{user_id}";
     const TEST_PROTECTED_ROUTE: &str = "/protected";
     const TEST_API_ROUTE: &str = "/api/protected";
 
-    fn get_test_server(cookie_duration: Duration) -> TestServer {
+    fn get_test_server() -> TestServer {
         let hash = sha2::Sha512::digest("nafstenoas");
+        let session_actor = SessionStore::spawn(SessionStore::new());
         let state = AuthState {
             cookie_key: Key::from(&hash),
-            cookie_duration,
-            local_timezone: "Etc/UTC".to_owned(),
+            session_actor,
         };
 
         let app = Router::new()
@@ -213,12 +209,12 @@ mod auth_guard_tests {
         TestServer::new(app)
     }
 
-    fn get_test_server_hx(cookie_duration: Duration) -> TestServer {
+    fn get_test_server_hx() -> TestServer {
         let hash = sha2::Sha512::digest("nafstenoas");
+        let session_actor = SessionStore::spawn(SessionStore::new());
         let state = AuthState {
             cookie_key: Key::from(&hash),
-            cookie_duration,
-            local_timezone: "Etc/UTC".to_owned(),
+            session_actor,
         };
 
         let app = Router::new()
@@ -231,7 +227,7 @@ mod auth_guard_tests {
 
     #[tokio::test]
     async fn get_protected_route_with_valid_cookie() {
-        let server = get_test_server(DEFAULT_COOKIE_DURATION);
+        let server = get_test_server();
         let response = server
             .post(&format_endpoint(TEST_LOG_IN_ROUTE_PATH, 1))
             .await;
@@ -247,8 +243,8 @@ mod auth_guard_tests {
     }
 
     #[tokio::test]
-    async fn auth_guard_sets_auth_and_expiry_cookies() {
-        let server = get_test_server(DEFAULT_COOKIE_DURATION);
+    async fn protected_route_with_valid_cookie_returns_ok() {
+        let server = get_test_server();
         let response = server
             .post(&format_endpoint(TEST_LOG_IN_ROUTE_PATH, 1))
             .await;
@@ -256,54 +252,16 @@ mod auth_guard_tests {
         response.assert_status_ok();
         let jar = response.cookies();
 
-        let response = server.get(TEST_PROTECTED_ROUTE).add_cookies(jar).await;
-        let jar = response.cookies();
-        assert!(
-            jar.get(COOKIE_TOKEN).is_some(),
-            "expected token cookie to be set by auth guard"
-        );
-    }
-
-    #[track_caller]
-    fn assert_date_time_close(left: OffsetDateTime, right: OffsetDateTime) {
-        assert!(
-            (left - right).abs() < Duration::seconds(1),
-            "got date time {:?}, want {:?}",
-            left,
-            right
-        );
-    }
-
-    #[tokio::test]
-    async fn auth_guard_extends_valid_cookie_duration() {
-        let server = get_test_server(Duration::seconds(5));
-        let response = server
-            .post(&format_endpoint(TEST_LOG_IN_ROUTE_PATH, 1))
-            .await;
-
-        response.assert_status_ok();
-        let response_time = OffsetDateTime::now_utc();
-        let jar = response.cookies();
-        assert_date_time_close(
-            jar.get(COOKIE_TOKEN).unwrap().expires_datetime().unwrap(),
-            response_time + Duration::seconds(5),
-        );
-
-        let response = server.get(TEST_PROTECTED_ROUTE).add_cookies(jar).await;
-
-        let auth_cookie = response.cookie(COOKIE_TOKEN);
-        assert_date_time_close(
-            auth_cookie.expires_datetime().unwrap(),
-            response_time + Duration::minutes(5),
-        );
-        assert_eq!(auth_cookie.secure(), Some(true));
-        assert_eq!(auth_cookie.http_only(), Some(true));
-        assert_eq!(auth_cookie.same_site(), Some(SameSite::Strict));
+        server
+            .get(TEST_PROTECTED_ROUTE)
+            .add_cookies(jar)
+            .await
+            .assert_status_ok();
     }
 
     #[tokio::test]
     async fn get_protected_route_with_no_auth_cookie_redirects_to_log_in() {
-        let server = get_test_server(DEFAULT_COOKIE_DURATION);
+        let server = get_test_server();
         let response = server.get(TEST_PROTECTED_ROUTE).await;
 
         response.assert_status_see_other();
@@ -315,7 +273,7 @@ mod auth_guard_tests {
 
     #[tokio::test]
     async fn get_protected_route_with_invalid_auth_cookie_redirects_to_log_in() {
-        let server = get_test_server(DEFAULT_COOKIE_DURATION);
+        let server = get_test_server();
         let response = server
             .get(TEST_PROTECTED_ROUTE)
             .add_cookie(Cookie::build((COOKIE_TOKEN, "FOOBAR")).build())
@@ -330,7 +288,7 @@ mod auth_guard_tests {
 
     #[tokio::test]
     async fn get_protected_route_with_expired_auth_cookie_redirects_to_log_in() {
-        let server = get_test_server(DEFAULT_COOKIE_DURATION);
+        let server = get_test_server();
         let response = server
             .post(&format_endpoint(TEST_LOG_IN_ROUTE_PATH, 1))
             .await;
@@ -353,7 +311,7 @@ mod auth_guard_tests {
 
     #[tokio::test]
     async fn api_route_uses_hx_current_url_for_redirect() {
-        let server = get_test_server_hx(DEFAULT_COOKIE_DURATION);
+        let server = get_test_server_hx();
         let current_url = "/transactions?range=month&anchor=2025-10-05";
         let response = server
             .get(TEST_API_ROUTE)

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -5,21 +5,20 @@ mod log_out;
 mod middleware;
 mod password;
 mod redirect;
+mod session;
 mod token;
 mod user;
 
-pub use cookie::{DEFAULT_COOKIE_DURATION, invalidate_auth_cookie, set_auth_cookie};
+use cookie::{invalidate_auth_cookie, set_auth_cookie};
 pub use forgot_password::get_forgot_password_page;
 pub use log_in::{get_log_in_page, post_log_in};
 pub use log_out::get_log_out;
 pub use middleware::{auth_guard, auth_guard_hx};
 pub use password::{PasswordHash, ValidatedPassword};
-pub(super) use redirect::{build_log_in_redirect_url, normalize_redirect_url};
-pub(super) use token::Token;
+use redirect::{build_log_in_redirect_url, normalize_redirect_url};
+pub use session::{SessionId, SessionStore, start_session_actor};
+use token::Token;
 pub use user::{User, UserID, create_user_table, get_user_by_id};
 
 #[cfg(test)]
-pub use cookie::COOKIE_TOKEN;
-
-#[cfg(test)]
-pub use middleware::AuthState;
+use cookie::COOKIE_TOKEN;

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -1,0 +1,339 @@
+use std::collections::HashMap;
+
+use kameo::{
+    Actor,
+    actor::{ActorRef, Spawn},
+    error::SendError,
+    prelude::{Context, Message},
+};
+use kameo_actors::scheduler::{Scheduler, SetInterval};
+use time::{Duration, UtcDateTime};
+use uuid::Uuid;
+
+const IDLE_TIMEOUT: Duration = Duration::minutes(15);
+/// The maximum allowed age for a session.
+pub const MAX_SESSION_AGE: Duration = Duration::hours(24);
+const CLEAR_EXPIRED_SESSION_INTERVAL: std::time::Duration = std::time::Duration::from_hours(1);
+
+/// A unique identifier for a session.
+pub type SessionId = Uuid;
+
+/// A user session with idle timeout and absolute max age.
+#[derive(Clone, Debug)]
+pub struct Session {
+    /// The unique identifier for this session.
+    pub id: SessionId,
+    /// When the session was created.
+    pub issued_at: UtcDateTime,
+    /// When the session expires (or expired).
+    pub expires_at: UtcDateTime,
+}
+
+impl Session {
+    /// Create a new session with a random UUID and expiry set to now +
+    /// `IDLE_TIMEOUT`.
+    pub fn new(now: UtcDateTime) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            issued_at: now,
+            expires_at: now + IDLE_TIMEOUT,
+        }
+    }
+
+    fn expired(&self, now: UtcDateTime) -> bool {
+        self.expires_at < now
+    }
+}
+
+/// An in-memory store for managing sessions
+#[derive(Actor)]
+#[actor(name = "SessionStore")]
+pub struct SessionStore {
+    sessions: HashMap<SessionId, Session>,
+}
+
+impl SessionStore {
+    /// Create an empty session store
+    pub fn new() -> Self {
+        Self {
+            sessions: HashMap::new(),
+        }
+    }
+}
+
+/// Insert a new session or overwrite an existing one.
+pub(super) struct Set {
+    pub session: Session,
+}
+
+impl Message<Set> for SessionStore {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: Set, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        self.sessions.insert(msg.session.id, msg.session);
+    }
+}
+
+/// Extend the idle timeout for a session. Returns `None` if the session is
+/// missing or expired — callers should treat `None` as unauthenticated.
+pub(super) struct Extend {
+    pub id: SessionId,
+    /// The current time, for checking expiry and computing the new deadline.
+    pub now: UtcDateTime,
+}
+
+impl Message<Extend> for SessionStore {
+    type Reply = Option<Session>;
+
+    async fn handle(&mut self, msg: Extend, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        let session = self.sessions.get(&msg.id).and_then(|session| {
+            if session.expired(msg.now) {
+                return None;
+            }
+
+            let new_expiry = msg.now + IDLE_TIMEOUT;
+            let max_expiry = session.issued_at + MAX_SESSION_AGE;
+
+            let expires_at = if new_expiry < max_expiry {
+                new_expiry
+            } else {
+                max_expiry
+            };
+
+            let updated = Session {
+                expires_at,
+                ..session.to_owned()
+            };
+
+            Some(updated)
+        });
+
+        match session {
+            Some(session) => {
+                self.sessions.insert(msg.id, session.clone());
+                Some(session)
+            }
+            None => {
+                self.sessions.remove(&msg.id);
+                None
+            }
+        }
+    }
+}
+
+/// Remove a session from the store.
+pub(super) struct Delete {
+    pub id: SessionId,
+}
+
+impl Message<Delete> for SessionStore {
+    type Reply = ();
+
+    async fn handle(&mut self, msg: Delete, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        self.sessions.remove_entry(&msg.id);
+    }
+}
+
+/// Clear all expired sessions from the store. When `now` is `None` the
+/// handler uses the current system time, which is the production path driven
+/// by the scheduler. Pass `Some(now)` in tests to simulate time.
+#[derive(Clone)]
+pub struct ClearExpiredSessions {
+    pub now: Option<UtcDateTime>,
+}
+
+impl ClearExpiredSessions {
+    fn resolve_now(&self) -> UtcDateTime {
+        self.now.unwrap_or_else(UtcDateTime::now)
+    }
+}
+
+impl Message<ClearExpiredSessions> for SessionStore {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: ClearExpiredSessions,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let now = msg.resolve_now();
+
+        self.sessions.retain(|_id, session| !session.expired(now));
+    }
+}
+/// Start the session store with a scheduler that clears expired sessions on a schedule.
+pub async fn start_session_actor() -> Result<
+    (ActorRef<SessionStore>, ActorRef<Scheduler>),
+    SendError<SetInterval<SessionStore, ClearExpiredSessions>>,
+> {
+    let session_actor = SessionStore::spawn(SessionStore::new());
+    let scheduler = Scheduler::spawn(Scheduler::new());
+
+    scheduler
+        .tell(SetInterval::new(
+            session_actor.downgrade(),
+            CLEAR_EXPIRED_SESSION_INTERVAL,
+            ClearExpiredSessions { now: None },
+        ))
+        .await?;
+
+    Ok((session_actor, scheduler))
+}
+
+#[cfg(test)]
+mod tests {
+    use kameo::actor::Spawn;
+    use time::macros::utc_datetime;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn session_new_computes_expiry_correctly() {
+        // Given a known point in time
+        let now = utc_datetime!(2025-06-15 12:00:00);
+
+        // When a session is created at that time
+        let session = Session::new(now);
+
+        // Then it has a non-nil UUID, correct timestamps, and correct expiry
+        assert!(!session.id.is_nil());
+        assert_eq!(session.issued_at, now);
+        assert_eq!(session.expires_at, now + IDLE_TIMEOUT);
+    }
+
+    #[tokio::test]
+    async fn extend_returns_none_for_expired_session() {
+        // Given a session that was created 16 minutes ago (beyond IDLE_TIMEOUT)
+        let now = utc_datetime!(2025-06-15 12:00:00);
+        let session = Session::new(now);
+        let store = SessionStore::spawn(SessionStore::new());
+        store
+            .tell(Set {
+                session: session.clone(),
+            })
+            .await
+            .unwrap();
+
+        // When extending the session 1 second after it expired
+        let after_expiry = session.expires_at + Duration::seconds(1);
+        let result = store
+            .ask(Extend {
+                id: session.id,
+                now: after_expiry,
+            })
+            .await
+            .unwrap();
+
+        // Then the result is None (session is expired)
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn extend_respects_max_session_age() {
+        // Given a session near its absolute max age
+        let base = utc_datetime!(2025-06-15 12:00:00);
+        let session_expiry = base + MAX_SESSION_AGE - Duration::minutes(1);
+        let session = Session {
+            id: Uuid::new_v4(),
+            issued_at: base,
+            expires_at: session_expiry,
+        };
+        let store = SessionStore::spawn(SessionStore::new());
+        store
+            .tell(Set {
+                session: session.clone(),
+            })
+            .await
+            .unwrap();
+
+        // When extending just before the absolute max age and before the session expiry
+        let near_max_age = session_expiry - Duration::minutes(1);
+        let result = store
+            .ask(Extend {
+                id: session.id,
+                now: near_max_age,
+            })
+            .await
+            .unwrap();
+
+        // Then the session is valid but new expiry is clamped to the max age
+        let extended = result.expect("session should still be valid");
+        assert_eq!(extended.expires_at, base + MAX_SESSION_AGE);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_session() {
+        // Given a valid session in the store
+        let now = utc_datetime!(2025-06-15 12:00:00);
+        let session = Session::new(now);
+        let store = SessionStore::spawn(SessionStore::new());
+        store
+            .tell(Set {
+                session: session.clone(),
+            })
+            .await
+            .unwrap();
+
+        // When the session is deleted
+        store.tell(Delete { id: session.id }).await.unwrap();
+
+        // Then extending it returns None
+        let result = store
+            .ask(Extend {
+                id: session.id,
+                now: now + Duration::minutes(1),
+            })
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn clear_expired_sessions_removes_only_expired() {
+        // Given one expired and one valid session in the store
+        let base = utc_datetime!(2025-06-15 12:00:00);
+        let expired = Session::new(base);
+        let valid = Session::new(base + Duration::minutes(10));
+        let store = SessionStore::spawn(SessionStore::new());
+        store
+            .tell(Set {
+                session: expired.clone(),
+            })
+            .await
+            .unwrap();
+        store
+            .tell(Set {
+                session: valid.clone(),
+            })
+            .await
+            .unwrap();
+
+        // When expired sessions are cleared at a time after the expired one's deadline
+        let clear_time = expired.expires_at + Duration::minutes(1);
+        store
+            .tell(ClearExpiredSessions {
+                now: Some(clear_time),
+            })
+            .await
+            .unwrap();
+
+        // Then the expired session is gone but the valid one remains
+        let result = store
+            .ask(Extend {
+                id: expired.id,
+                now: clear_time,
+            })
+            .await
+            .unwrap();
+        assert!(result.is_none(), "expired session should have been removed");
+
+        let result = store
+            .ask(Extend {
+                id: valid.id,
+                now: clear_time,
+            })
+            .await
+            .unwrap();
+        assert!(result.is_some(), "valid session should still be present");
+    }
+}

--- a/src/auth/token.rs
+++ b/src/auth/token.rs
@@ -1,74 +1,26 @@
-//! Defines the token struct used in the auth cookies and now to serialize/deserialize a token.
+//! Defines the token struct used in the auth cookies.
 
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 
-use crate::auth::UserID;
-
-mod datetime_format {
-    //! Specifies how to serialize a [time::OffsetDateTime] in a custom format that
-    //! avoids serialisations with datetimes containing midnight.
-    //!
-    //! The default serializer for [time::OffsetDateTime] will serialize
-    //! "00:00:00.000000" as "0:00:00.0" and the deserializer would error out
-    //! because it expects the hours to be two digits, not one.
-    use serde::{Deserialize, Deserializer, Serializer};
-    use time::{
-        OffsetDateTime, format_description::BorrowedFormatItem, macros::format_description,
-    };
-
-    /// Date time format for the cookie expiry, e.g. "2021-01-01 00:00:00.000000 +00:00:00".
-    const DATE_TIME_FORMAT: &[BorrowedFormatItem] = format_description!(
-        "[year]-[month]-[day] [hour]:[minute]:[second].[subsecond] [offset_hour \
-             sign:mandatory]:[offset_minute]:[offset_second]"
-    );
-
-    pub fn serialize<S>(dt: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let formatted = dt
-            .format(DATE_TIME_FORMAT)
-            .map_err(serde::ser::Error::custom)?;
-        serializer.serialize_str(&formatted)
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        OffsetDateTime::parse(&s, DATE_TIME_FORMAT).map_err(serde::de::Error::custom)
-    }
-}
+use crate::auth::SessionId;
 
 /// A token for authorization and authentication.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Token {
-    pub user_id: UserID,
-
-    #[serde(
-        serialize_with = "datetime_format::serialize",
-        deserialize_with = "datetime_format::deserialize"
-    )]
-    pub expires_at: OffsetDateTime,
+    pub session_id: SessionId,
 }
 
 #[cfg(test)]
 mod tests {
-    use time::{UtcOffset, macros::datetime};
+    use uuid::Uuid;
 
-    use crate::{UserID, auth::token::Token};
+    use crate::auth::token::Token;
 
     #[test]
     fn serialise_token() {
-        let user_id = UserID::new(1);
-        let expires_at = datetime!(2025-12-21 03:54:00).assume_offset(UtcOffset::UTC);
-        let token = Token {
-            user_id,
-            expires_at,
-        };
-        let expected = r#"{"user_id":1,"expires_at":"2025-12-21 03:54:00.0 +00:00:00"}"#;
+        let session_id = Uuid::parse_str("6c84fb90-12c4-11e1-840d-7b25c5ee775a").unwrap();
+        let token = Token { session_id };
+        let expected = r#"{"session_id":"6c84fb90-12c4-11e1-840d-7b25c5ee775a"}"#;
 
         let actual = serde_json::to_string(&token).unwrap();
 
@@ -77,31 +29,13 @@ mod tests {
 
     #[test]
     fn deserialise_token() {
-        let user_id = UserID::new(1);
-        let expires_at = datetime!(2025-12-21 03:54:00).assume_offset(UtcOffset::UTC);
-        let expected = Token {
-            user_id,
-            expires_at,
-        };
-        let token_string = r#"{"user_id":1,"expires_at":"2025-12-21 03:54:00.0 +00:00:00"}"#;
+        let token_string = r#"{"session_id":"6c84fb90-12c4-11e1-840d-7b25c5ee775a"}"#;
 
-        let actual = serde_json::from_str(token_string).unwrap();
+        let actual: Token = serde_json::from_str(token_string).unwrap();
 
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn deserialise_token_with_midnight_expiry() {
-        let user_id = UserID::new(1);
-        let expires_at = datetime!(2025-12-21 00:00:00).assume_offset(UtcOffset::UTC);
-        let expected = Token {
-            user_id,
-            expires_at,
-        };
-        let token_string = r#"{"user_id":1,"expires_at":"2025-12-21 00:00:00.0 +00:00:00"}"#;
-
-        let actual = serde_json::from_str(token_string).unwrap();
-
-        assert_eq!(expected, actual);
+        assert_eq!(
+            actual.session_id,
+            Uuid::parse_str("6c84fb90-12c4-11e1-840d-7b25c5ee775a").unwrap()
+        );
     }
 }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -18,7 +18,10 @@ use tower_http::trace::TraceLayer;
 use tower_livereload::LiveReloadLayer;
 use tracing_subscriber::{Layer, filter, layer::SubscriberExt, util::SubscriberInitExt};
 
-use budgeteur_rs::{AppState, build_router, graceful_shutdown, initialize_db, logging_middleware};
+use budgeteur_rs::{
+    AppState, build_router, graceful_shutdown, initialize_db, logging_middleware,
+    start_session_actor,
+};
 
 /// The REST API server for budgeteur_rs.
 #[derive(Parser, Debug)]
@@ -79,7 +82,10 @@ async fn main() {
         eprint!("{} is not a valid timezone name.", args.timezone.unwrap());
         exit(1);
     };
-    let app_config = AppState::new(conn, &secret, &timezone);
+    let (session_actor, scheduler) = start_session_actor()
+        .await
+        .expect("Could not start session actor");
+    let app_config = AppState::new(conn, &secret, &timezone, session_actor, scheduler);
 
     let handle = Handle::new();
     tokio::spawn(graceful_shutdown(handle.clone()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,9 @@ mod timezone;
 mod transaction;
 
 pub use app_state::AppState;
-pub use auth::{PasswordHash, User, UserID, ValidatedPassword, get_user_by_id};
+pub use auth::{
+    PasswordHash, User, UserID, ValidatedPassword, get_user_by_id, start_session_actor,
+};
 pub use db::initialize as initialize_db;
 pub use error::Error;
 pub use logging::{LOG_BODY_LENGTH_LIMIT, logging_middleware};


### PR DESCRIPTION
## Summary

- Replaces the cookie-based auth expiry system with an in-memory server-side session store using the Kameo actor framework.
- Sessions use UUID v4 IDs with idle timeout (15 min) and absolute max age (24h).
- All time-dependent messages (`Session::new`, `Extend`) accept an explicit timestamp for deterministic testing.

## Changes

- **New**: `src/auth/session.rs` — `SessionStore` actor with `Set`, `Extend`, `Delete`, `ClearExpiredSessions` messages
- **Simplified**: Cookies only hold a session ID; server manages expiry independently
- **Removed**: Remember-me checkbox, cookie duration extension, custom datetime serialization, `cookie_duration` from `AppState`
- **Middleware**: Validates sessions via `Extend` (atomic verify+extend), no cookie manipulation in response
- **Tests**: 231 passing, including 4 direct session store tests covering expiry, max age clamping, deletion

## Test plan

- [x] All 231 tests pass
- [x] Clippy clean
- [x] Session expiry (idle timeout) verified
- [x] Max age clamping verified
- [x] Session deletion via logout verified


💘 Generated with Crush