### PR TITLE
fix(web): Fix missing CSS styles in Docker image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "budgeteur_rs"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "axum",
  "axum-extra",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "budgeteur_shared"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "numfmt",
  "serde",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "budgeteur_tui"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "budgeteur_shared",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,5 @@ resolver = "2"
 members = ["server", "tui", "shared"]
 
 [workspace.package]
-version = "0.30.1"
+version = "0.30.2"
 edition = "2024"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ RUN apk update
 RUN apk add --no-cache curl libgcc libstdc++
 
 WORKDIR /build
-COPY server/src/input.css /build/input.css
+COPY server/src /build/src
 RUN curl -sL https://github.com/tailwindlabs/tailwindcss/releases/download/v4.1.18/tailwindcss-linux-x64-musl -o tailwindcss && \
   chmod +x tailwindcss && \
-  ./tailwindcss --input input.css --output static/main.css --minify
+  ./tailwindcss --input src/input.css --output static/main.css --minify
 
 #==============================================================================#
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,10 @@
 ## Side Quest: Multi-Client Support (TUI)
 
 - Add subcommand to print config path
+- Add argument for TUI to override the private key path.
+  Useful for testing dev version alongside prod version
+- Log full errors somewhere, keep errors in UI brief
+- Enforce that version in flake.nix matches that in Cargo.toml
 - Dashboard view
   - Rearrange to put expenses by tag and untagged transaction on a third row that fills the height
   - Set ignored tags similar to dashboard
@@ -30,6 +34,12 @@
 - Tags view
 - Auto-tagging rules view
 - Enforce a minimum screen size
+
+### Bugs
+
+- Dashboard:
+  - When there's no untagged transactions, the "A" in "Amount" gets cut off
+  - The refresh command shows twice
 
 ## Stage One: Budgeting
 

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
 
         budgeteur = pkgs.rustPlatform.buildRustPackage {
           pname = "budgeteur";
-          version = "0.30.0";
+          version = "0.30.2";
 
           src = ./.;
 


### PR DESCRIPTION
Styles were broken because the Docker image was only copying over the CSS config file, whereas the Tailwind compiler needs the source code with the Tailwind classes.