### PR TITLE
fix: Avoid NaN/Infinity and OOB panic in spending pace endpoint

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 ## Side Quest: Multi-Client Support (TUI)
 
+- Change savings summary to TTM
 - Add subcommand to print config path
 - Add argument for TUI to override the private key path.
   Useful for testing dev version alongside prod version

--- a/server/src/dashboard/json.rs
+++ b/server/src/dashboard/json.rs
@@ -329,7 +329,6 @@ fn compute_spending_pace(
     mean_monthly_expenses: f64,
 ) -> SpendingPaceStats {
     let current_month = first_of_month(today);
-    let day_count = days_in_month(today.year(), today.month()) as usize;
 
     // Separate current-month expenses from historical ones.
     let (current_txns, historical_txns): (Vec<&Transaction>, Vec<&Transaction>) = transactions
@@ -337,45 +336,37 @@ fn compute_spending_pace(
         .filter(|t| t.amount < 0.0)
         .partition(|t| first_of_month(t.date) == current_month);
 
+    let current_month_days = days_in_month(today.year(), today.month()) as usize;
+
     let historical: Vec<f64> = {
-        let mut sum_by_day = vec![0.0; day_count];
-        let mut unique_months_seen_by_day: BTreeMap<usize, HashSet<(Month, i32)>> = BTreeMap::new();
-        for t in historical_txns {
-            let day = (t.date.day() - 1) as usize;
-            sum_by_day[day] = sum_by_day.get(day).copied().unwrap_or(0.0) + t.amount.abs();
+        let mut amounts_by_day: BTreeMap<usize, f64> = BTreeMap::new();
+        let mut months_by_day: BTreeMap<usize, HashSet<(Month, i32)>> = BTreeMap::new();
+        for t in &historical_txns {
+            let day_idx = t.date.day() as usize - 1;
+            *amounts_by_day.entry(day_idx).or_insert(0.0) += t.amount.abs();
+            months_by_day
+                .entry(day_idx)
+                .or_default()
+                .insert((t.date.month(), t.date.year()));
+        }
 
-            if let Some(unique_months) = unique_months_seen_by_day.get_mut(&day) {
-                unique_months.insert((t.date.month(), t.date.year()));
+        let mut historical = vec![0.0; current_month_days];
+        for day_idx in 1..current_month_days {
+            let total = amounts_by_day.get(&day_idx).copied().unwrap_or(0.0);
+            let month_count = months_by_day.get(&day_idx).map(|s| s.len()).unwrap_or(0);
+            let daily_avg = if month_count > 0 {
+                total / month_count as f64
             } else {
-                let mut unique_months = HashSet::new();
-                unique_months.insert((t.date.month(), t.date.year()));
-                unique_months_seen_by_day.insert(day, unique_months);
-            }
-        }
-
-        let mut sample_count_by_day = vec![0; day_count];
-        for (day, count) in sample_count_by_day.iter_mut().enumerate().take(day_count) {
-            *count = unique_months_seen_by_day
-                .get(&day)
-                .map(|s| s.len())
-                .unwrap_or(0);
-        }
-
-        let mut historical = vec![0.0; day_count];
-        for (day, (total, count)) in sum_by_day.iter().zip(sample_count_by_day).enumerate() {
-            let Some(previous_day) = day.checked_sub(1) else {
-                continue;
+                0.0
             };
-            let previous_total = historical.get(previous_day).copied().unwrap_or(0.0);
-            let todays_total = if count > 0 { total / count as f64 } else { 0.0 };
-            historical[day] = round_two_dp(todays_total + previous_total);
+            historical[day_idx] = round_two_dp(daily_avg + historical[day_idx - 1]);
         }
 
         historical
     };
 
     let (current, last_day_with_data) = {
-        let mut sum_by_day = vec![0.0; day_count];
+        let mut sum_by_day = vec![0.0; current_month_days];
         let mut last_day_with_data = current_month;
         for t in current_txns {
             let day = (t.date.day() - 1) as usize;
@@ -405,7 +396,11 @@ fn compute_spending_pace(
 
     let baseline = historical[last_day_with_data - 1];
     let deviation_from_baseline = current[last_day_with_data - 1] - baseline;
-    let deviation_from_baseline_ratio = deviation_from_baseline / baseline;
+    let deviation_from_baseline_ratio = if baseline != 0.0 {
+        Some(deviation_from_baseline / baseline)
+    } else {
+        None
+    };
 
     SpendingPaceStats {
         historical,
@@ -821,7 +816,7 @@ mod tests {
         assert_eq!(result.historical[1], 10.0);
         assert_eq!(result.current[0], 0.0);
         assert_eq!(result.deviation_from_baseline, 0.0);
-        assert!(result.deviation_from_baseline_ratio.is_nan());
+        assert!(result.deviation_from_baseline_ratio.is_none());
     }
 
     #[test]
@@ -836,10 +831,7 @@ mod tests {
         // Only current month transactions, no history
         assert!(result.historical.iter().all(|&x| x == 0.0));
         assert!(result.deviation_from_baseline > 0.0);
-        assert!(
-            result.deviation_from_baseline_ratio.is_infinite()
-                && result.deviation_from_baseline_ratio.is_sign_positive()
-        );
+        assert!(result.deviation_from_baseline_ratio.is_none());
     }
 
     // -----------------------------------------------------------------------

--- a/shared/src/dashboard.rs
+++ b/shared/src/dashboard.rs
@@ -49,7 +49,10 @@ pub struct SpendingPaceStats {
     /// This assumes the you will continue to spend at your typical rate.
     pub deviation_from_baseline: f64,
     /// The expected difference between the end of month expenses as a ratio.
-    pub deviation_from_baseline_ratio: f64,
+    ///
+    /// `None` indicates that the baseline is not meaningful, e.g. it is the
+    /// start of the month where the baseline is zero, and the current spending is zero.
+    pub deviation_from_baseline_ratio: Option<f64>,
     /// The mean monthly expentiture as an absolute value.
     pub mean_monthly_expenses: f64,
 }

--- a/tui/src/dashboard.rs
+++ b/tui/src/dashboard.rs
@@ -551,7 +551,8 @@ fn draw_spending_block(
     let [amount_area, chart_area] = block.inner(area).layout(&layout);
 
     let amount = match data.deviation_from_baseline_ratio {
-        x if x > 0.05 => Text::from(vec![
+        None => Text::from("NM".dark_gray()),
+        Some(x) if x > 0.05 => Text::from(vec![
             Line::from(vec![
                 "This month you are on track to spend ".dark_gray(),
                 format_currency_rounded(data.deviation_from_baseline.abs()).red(),
@@ -563,7 +564,7 @@ fn draw_spending_block(
             ])
             .dark_gray(),
         ]),
-        x if x < -0.05 => Text::from(vec![
+        Some(x) if x < -0.05 => Text::from(vec![
             Line::from(vec![
                 "This month you are on track to spend ".dark_gray(),
                 format_currency_rounded(data.deviation_from_baseline.abs()).gray(),
@@ -630,11 +631,15 @@ fn draw_spending_block(
             .name("Spending MTD")
             .marker(Marker::Braille)
             .graph_type(GraphType::Line)
-            .style(if data.deviation_from_baseline_ratio > 0.05 {
-                Color::Red
-            } else {
-                Color::Gray
-            })
+            .style(
+                if let Some(deviation_ratio) = data.deviation_from_baseline_ratio
+                    && deviation_ratio > 0.05
+                {
+                    Color::Red
+                } else {
+                    Color::Gray
+                },
+            )
             .data(&current_month_data),
     ];
 


### PR DESCRIPTION
The `deviation_from_baseline_ratio` was `f64`, leaking NaN (0/0) and Infinity (x/0) through the API when the historical baseline was zero. Changed it to `Option<f64>` — `None` when the baseline is zero, displayed as "NM" (not meaningful) in the TUI.

The OOB panic occurred at `sum_by_day[day]` when a historical transaction's day-of-month (e.g. 31) exceeded the current month's day count (e.g. 30). The root cause was an implicit dependency between the array size (current month days) and the index source (historical transaction days). The fix replaces the push-based triple-array approach (sum_by_day, unique_months_seen_by_day, sample_count_by_day) with a pull-based design: group historical transactions into BTreeMaps by day-of-month, then iterate 1..current_month_days to build the cumulative array. Maps have no bounds, and the loop range matches the array size — safety is structural rather than enforced by a remote filter.